### PR TITLE
New resource: `herokux_kafka_topic`

### DIFF
--- a/api/examples/kafka/main.go
+++ b/api/examples/kafka/main.go
@@ -16,7 +16,11 @@ func main() {
 		panic(clientInitErr)
 	}
 
-	opts := kafka.NewTopicRequest("SOME_TOPIC_NAME", 3, "3d")
+	time := 123456
+	opts := &kafka.TopicRequest{}
+	opts.Name = "SOME_TOPIC_NAME"
+	opts.Partitions = 3
+	opts.RetentionTimeMS = &time
 	opts.Compaction = true
 	opts.Partitions = 6
 

--- a/api/kafka/consumer_groups.go
+++ b/api/kafka/consumer_groups.go
@@ -40,7 +40,7 @@ func (k *Kafka) ListConsumerGroups(clusterID string) (*ConsumerGroups, *simplere
 	return result, response, getErr
 }
 
-func (k *Kafka) FindConsumerGroupByName(clusterID, groupName string) (*ConsumerGroup, *simpleresty.Response, error) {
+func (k *Kafka) GetConsumerGroupByName(clusterID, groupName string) (*ConsumerGroup, *simpleresty.Response, error) {
 	groups, _, listErr := k.ListConsumerGroups(clusterID)
 	if listErr != nil {
 		return nil, nil, listErr

--- a/api/kafka/helper_test.go
+++ b/api/kafka/helper_test.go
@@ -9,7 +9,7 @@ func TestConvertDurationToMilliseconds_MS_Valid(t *testing.T) {
 	expected := 2454665
 
 	for _, d := range []string{"2454665ms", "2454665millisecond", "2454665milliseconds"} {
-		v, err := convertDurationToMilliseconds(d)
+		v, err := ConvertDurationToMilliseconds(d)
 		assert.Nil(t, err)
 		assert.Equal(t, expected, v)
 	}
@@ -19,7 +19,7 @@ func TestConvertDurationToMilliseconds_S_Valid(t *testing.T) {
 	expected := 9845000
 
 	for _, d := range []string{"9845s", "9845second", "9845seconds"} {
-		v, err := convertDurationToMilliseconds(d)
+		v, err := ConvertDurationToMilliseconds(d)
 		assert.Nil(t, err)
 		assert.Equal(t, expected, v)
 	}
@@ -29,7 +29,7 @@ func TestConvertDurationToMilliseconds_M_Valid(t *testing.T) {
 	expected := 590700000
 
 	for _, d := range []string{"9845m", "9845minute", "9845minutes"} {
-		v, err := convertDurationToMilliseconds(d)
+		v, err := ConvertDurationToMilliseconds(d)
 		assert.Nil(t, err)
 		assert.Equal(t, expected, v)
 	}
@@ -39,7 +39,7 @@ func TestConvertDurationToMilliseconds_H_Valid(t *testing.T) {
 	expected := 277200000
 
 	for _, d := range []string{"77h", "77hour", "77hours"} {
-		v, err := convertDurationToMilliseconds(d)
+		v, err := ConvertDurationToMilliseconds(d)
 		assert.Nil(t, err)
 		assert.Equal(t, expected, v)
 	}
@@ -49,7 +49,7 @@ func TestConvertDurationToMilliseconds_D_Valid(t *testing.T) {
 	expected := 1209600000
 
 	for _, d := range []string{"14d", "14day", "14days"} {
-		v, err := convertDurationToMilliseconds(d)
+		v, err := ConvertDurationToMilliseconds(d)
 		assert.Nil(t, err)
 		assert.Equal(t, expected, v)
 	}
@@ -59,7 +59,7 @@ func TestConvertDurationToMilliseconds_W_Valid(t *testing.T) {
 	expected := 1814400000
 
 	for _, d := range []string{"3w", "3week", "3weeks"} {
-		v, err := convertDurationToMilliseconds(d)
+		v, err := ConvertDurationToMilliseconds(d)
 		assert.Nil(t, err)
 		assert.Equal(t, expected, v)
 	}
@@ -67,8 +67,71 @@ func TestConvertDurationToMilliseconds_W_Valid(t *testing.T) {
 
 func TestConvertDurationToMilliseconds_Invalid(t *testing.T) {
 	testDuration := "1month"
-	v, err := convertDurationToMilliseconds(testDuration)
+	v, err := ConvertDurationToMilliseconds(testDuration)
 	assert.NotNil(t, err)
 	assert.Equal(t, 0, v)
 
+}
+
+func TestConvertMStoDuration_Week(t *testing.T) {
+	expected := "2w"
+	testMS := 1209600000
+
+	result, err := ConvertMillisecondstoDuration(testMS)
+	assert.Nil(t, err)
+	assert.Equal(t, expected, result)
+}
+
+func TestConvertMStoDuration_Day(t *testing.T) {
+	expected := "8d"
+	testMS := 691200000
+
+	result, err := ConvertMillisecondstoDuration(testMS)
+	assert.Nil(t, err)
+	assert.Equal(t, expected, result)
+}
+
+func TestConvertMStoDuration_Hour(t *testing.T) {
+	expected := "47h"
+	testMS := 169200000
+
+	result, err := ConvertMillisecondstoDuration(testMS)
+	assert.Nil(t, err)
+	assert.Equal(t, expected, result)
+}
+
+func TestConvertMStoDuration_Minute(t *testing.T) {
+	expected := "123m"
+	testMS := 7380000
+
+	result, err := ConvertMillisecondstoDuration(testMS)
+	assert.Nil(t, err)
+	assert.Equal(t, expected, result)
+}
+
+func TestConvertMStoDuration_Second(t *testing.T) {
+	expected := "123s"
+	testMS := 123000
+
+	result, err := ConvertMillisecondstoDuration(testMS)
+	assert.Nil(t, err)
+	assert.Equal(t, expected, result)
+}
+
+func TestConvertMStoDuration_Millisecond(t *testing.T) {
+	expected := "12300ms"
+	testMS := 12300
+
+	result, err := ConvertMillisecondstoDuration(testMS)
+	assert.Nil(t, err)
+	assert.Equal(t, expected, result)
+}
+
+func TestConvertMStoDuration_HigherDurationWins(t *testing.T) {
+	expected := "1w"
+	testMS := 604800000
+
+	result, err := ConvertMillisecondstoDuration(testMS)
+	assert.Nil(t, err)
+	assert.Equal(t, expected, result)
 }

--- a/api/kafka/kafka-accessors.go
+++ b/api/kafka/kafka-accessors.go
@@ -561,12 +561,12 @@ func (t *Topic) GetPrefix() string {
 	return *t.Prefix
 }
 
-// GetReplacementFactor returns the ReplacementFactor field if it's non-nil, zero value otherwise.
-func (t *Topic) GetReplacementFactor() int {
-	if t == nil || t.ReplacementFactor == nil {
+// GetReplicationFactor returns the ReplicationFactor field if it's non-nil, zero value otherwise.
+func (t *Topic) GetReplicationFactor() int {
+	if t == nil || t.ReplicationFactor == nil {
 		return 0
 	}
-	return *t.ReplacementFactor
+	return *t.ReplicationFactor
 }
 
 // GetRetentionEnabled returns the RetentionEnabled field if it's non-nil, zero value otherwise.
@@ -607,6 +607,14 @@ func (t *TopicLimits) GetMaxTopics() int {
 		return 0
 	}
 	return *t.MaxTopics
+}
+
+// GetRetentionTimeMS returns the RetentionTimeMS field if it's non-nil, zero value otherwise.
+func (t *TopicRequest) GetRetentionTimeMS() int {
+	if t == nil || t.RetentionTimeMS == nil {
+		return 0
+	}
+	return *t.RetentionTimeMS
 }
 
 // GetAddonAttachmentConfigVar returns the AddonAttachmentConfigVar field if it's non-nil, zero value otherwise.

--- a/api/kafka/types.go
+++ b/api/kafka/types.go
@@ -20,3 +20,30 @@ var ConsumerGroupStatuses = struct {
 func (s ConsumerGroupStatus) ToString() string {
 	return string(s)
 }
+
+// TopicStatus represent the status of a topic
+type TopicStatus string
+
+// TopicStatuses represent all statuses pertaining to the lifecycle of a topic
+var TopicStatuses = struct {
+	PENDING  TopicStatus
+	CREATED  TopicStatus
+	READY    TopicStatus
+	UPDATING TopicStatus
+	UPDATED  TopicStatus
+	DELETED  TopicStatus
+	UNKNOWN  TopicStatus
+}{
+	PENDING:  "pending",
+	CREATED:  "created",
+	READY:    "ready",
+	UPDATING: "updating",
+	UPDATED:  "updated",
+	DELETED:  "deleted",
+	UNKNOWN:  "Unknown",
+}
+
+// ToString is a helper method to return the string of a TopicStatus.
+func (s TopicStatus) ToString() string {
+	return string(s)
+}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.14
 
 require (
 	github.com/davidji99/simpleresty v0.2.3
+	github.com/elliotchance/orderedmap v1.3.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.0.1
 	github.com/stretchr/testify v1.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -67,6 +67,8 @@ github.com/davidji99/go-querystring v1.0.2 h1:zZUgCkhdFEsb0b1tS1zhn7FwjoRyp33J3b
 github.com/davidji99/go-querystring v1.0.2/go.mod h1:67KzURpYgsT0d/eszawoSvtpI+34vczasEK3xgrxrqA=
 github.com/davidji99/simpleresty v0.2.3 h1:oUHimRSFUgGgJjd+65q3L9alzPF3vFBiXHKxVVmkvkU=
 github.com/davidji99/simpleresty v0.2.3/go.mod h1:v1honpRzBWA0G2Ivpz3ozeaB4zRiYxvu8CAAAtAlHqY=
+github.com/elliotchance/orderedmap v1.3.0 h1:k6m77/d0zCXTjsk12nX40TkEBkSICq8T4s6R6bpCqU0=
+github.com/elliotchance/orderedmap v1.3.0/go.mod h1:8hdSl6jmveQw8ScByd3AaNHNk51RhbTazdqtTty+NFw=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=

--- a/herokux/config.go
+++ b/herokux/config.go
@@ -16,6 +16,8 @@ const (
 	DefaultMTLSCertificateDeleteTimeout = int64(10)
 	DefaultKafkaCGCreateTimeout         = int64(10)
 	DefaultKafkaCGDeleteTimeout         = int64(10)
+	DefaultKafkaTopicCreateTimeout      = int64(10)
+	DefaultKafkaTopicUpdateTimeout      = int64(10)
 )
 
 type Config struct {
@@ -33,6 +35,8 @@ type Config struct {
 	MTLSCertificateDeleteTimeout int64
 	KafkaCGCreateTimeout         int64
 	KafkaCGDeleteTimeout         int64
+	KafkaTopicCreateTimeout      int64
+	KafkaTopicUpdateTimeout      int64
 }
 
 func NewConfig() *Config {
@@ -44,6 +48,8 @@ func NewConfig() *Config {
 		MTLSCertificateDeleteTimeout: DefaultMTLSCertificateDeleteTimeout,
 		KafkaCGCreateTimeout:         DefaultKafkaCGCreateTimeout,
 		KafkaCGDeleteTimeout:         DefaultKafkaCGDeleteTimeout,
+		KafkaTopicCreateTimeout:      DefaultKafkaTopicCreateTimeout,
+		KafkaTopicUpdateTimeout:      DefaultKafkaTopicUpdateTimeout,
 	}
 	return c
 }
@@ -117,6 +123,14 @@ func (c *Config) applySchema(d *schema.ResourceData) (err error) {
 
 			if v, ok := delaysConfig["kafka_cg_delete_timeout"].(int); ok {
 				c.KafkaCGDeleteTimeout = int64(v)
+			}
+
+			if v, ok := delaysConfig["kafka_topic_create_timeout"].(int); ok {
+				c.KafkaTopicCreateTimeout = int64(v)
+			}
+
+			if v, ok := delaysConfig["kafka_topic_update_timeout"].(int); ok {
+				c.KafkaTopicUpdateTimeout = int64(v)
 			}
 		}
 	}

--- a/herokux/import_herokux_kafka_topic_test.go
+++ b/herokux/import_herokux_kafka_topic_test.go
@@ -1,0 +1,30 @@
+package herokux
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"testing"
+)
+
+func TestAccHerokuxKafkaTopic_importBasic(t *testing.T) {
+	kafkaID := testAccConfig.GetKafkaIDorSkip(t)
+	topicName := fmt.Sprintf("tftest-%s", acctest.RandString(15))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckHerokuxKafkaTopic_basic(kafkaID, topicName),
+			},
+			{
+				ResourceName:      "herokux_kafka_topic.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/herokux/provider.go
+++ b/herokux/provider.go
@@ -90,6 +90,20 @@ func New() *schema.Provider {
 							Default:      10,
 							ValidateFunc: validation.IntAtLeast(1),
 						},
+
+						"kafka_topic_create_timeout": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Default:      10,
+							ValidateFunc: validation.IntAtLeast(3),
+						},
+
+						"kafka_topic_update_timeout": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Default:      10,
+							ValidateFunc: validation.IntAtLeast(3),
+						},
 					},
 				},
 			},
@@ -102,6 +116,7 @@ func New() *schema.Provider {
 		ResourcesMap: map[string]*schema.Resource{
 			"herokux_formation_autoscaling":     resourceHerokuxFormationAutoscaling(),
 			"herokux_kafka_consumer_group":      resourceHerokuxKafkaConsumerGroup(),
+			"herokux_kafka_topic":               resourceHerokuxKafkaTopic(),
 			"herokux_postgres_mtls":             resourceHerokuxPostgresMTLS(),
 			"herokux_postgres_mtls_certificate": resourceHerokuxPostgresMTLSCertificate(),
 			"herokux_postgres_mtls_iprule":      resourceHerokuxPostgresMTLSIPRule(),

--- a/herokux/resource_herokux_kafka_consumer_group.go
+++ b/herokux/resource_herokux_kafka_consumer_group.go
@@ -97,7 +97,7 @@ func resourceHerokuxKafkaConsumerGroupRead(ctx context.Context, d *schema.Resour
 		return diag.FromErr(parseErr)
 	}
 
-	group, _, getErr := client.Kafka.FindConsumerGroupByName(result[0], result[1])
+	group, _, getErr := client.Kafka.GetConsumerGroupByName(result[0], result[1])
 	if getErr != nil {
 		return diag.FromErr(getErr)
 	}

--- a/herokux/resource_herokux_kafka_topic.go
+++ b/herokux/resource_herokux_kafka_topic.go
@@ -1,0 +1,387 @@
+package herokux
+
+import (
+	"context"
+	"fmt"
+	"github.com/davidji99/terraform-provider-herokux/api"
+	"github.com/davidji99/terraform-provider-herokux/api/kafka"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"log"
+	"regexp"
+	"time"
+)
+
+func resourceHerokuxKafkaTopic() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceHerokuxKafkaTopicCreate,
+		ReadContext:   resourceHerokuxKafkaTopicRead,
+		UpdateContext: resourceHerokuxKafkaTopicUpdate,
+		DeleteContext: resourceHerokuxKafkaTopicDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceHerokuxKafkaTopicImport,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"kafka_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.IsUUID,
+			},
+
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"partitions": {
+				Type:     schema.TypeInt,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"replication_factor": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      3,
+				ValidateFunc: validation.IntAtLeast(3),
+			},
+
+			"retention_time": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      "1d",
+				ValidateFunc: validateRetentionTime,
+			},
+
+			"compaction": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"cleanup_policy": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func validateRetentionTime(v interface{}, k string) (ws []string, errors []error) {
+	duration := v.(string)
+
+	// First validate the retention time is defined in a supported value.
+	if !regexp.MustCompile(kafka.RetentionTimeDuragionRegexStricterWithDisable).MatchString(duration) {
+		errors = append(errors, fmt.Errorf(
+			"Unsupported retention time %s. Format needs to be in `##ms|s|m|h|d|w` or `disable`", duration))
+		return
+	}
+
+	// Do not test for retention time minimum if the value is 'disable'
+	if duration != kafka.RetentionTimeDisableVal {
+		// Then verify that the retention time is set to a value that's at least 24 hours.
+		minRetentionTime, _ := kafka.ConvertDurationToMilliseconds("24h")
+		durationInt, _ := kafka.ConvertDurationToMilliseconds(duration)
+
+		if durationInt < minRetentionTime {
+			errors = append(errors, fmt.Errorf("you must specify a retention time that is at least 24 hours equivalent or greater"))
+		}
+	}
+
+	return
+}
+
+func resourceHerokuxKafkaTopicImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	d.SetId(d.Id())
+
+	readErr := resourceHerokuxKafkaTopicRead(ctx, d, meta)
+	if readErr.HasError() {
+		return nil, fmt.Errorf("unable to import resource")
+	}
+
+	return []*schema.ResourceData{d}, nil
+}
+
+func resourceHerokuxKafkaTopicCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*Config)
+	client := config.API
+	opts := &kafka.TopicRequest{}
+
+	kafkaID := getKakfaID(d)
+
+	if v, ok := d.GetOk("name"); ok {
+		vs := v.(string)
+		log.Printf("[DEBUG] topic name is : %v", vs)
+		opts.Name = vs
+	}
+
+	if v, ok := d.GetOk("partitions"); ok {
+		vs := v.(int)
+		log.Printf("[DEBUG] topic partitions is : %v", vs)
+		opts.Partitions = vs
+	}
+
+	if v, ok := d.GetOk("replication_factor"); ok {
+		vs := v.(int)
+		log.Printf("[DEBUG] topic replication_factor is : %v", vs)
+		opts.ReplicationFactor = vs
+	}
+
+	if v, ok := d.GetOk("retention_time"); ok {
+		duration := v.(string)
+		log.Printf("[DEBUG] topic retention_time (string) is : %v", duration)
+
+		// Convert the duration to milliseconds as that's what is supported by the API
+		// unless the attribute value is `disable`. If it is disable,
+		// then set the opts.RetentionTimeMS to nil.
+		if duration == kafka.RetentionTimeDisableVal {
+			opts.RetentionTimeMS = nil
+			log.Printf("[DEBUG] topic new retention_time (int) is : %v", "nil")
+		} else {
+			ms, conErr := kafka.ConvertDurationToMilliseconds(duration)
+			if conErr != nil {
+				return diag.FromErr(conErr)
+			}
+			opts.RetentionTimeMS = &ms
+			log.Printf("[DEBUG] topic new retention_time (int) is : %v", ms)
+		}
+	}
+
+	if v, ok := d.GetOk("compaction"); ok {
+		vs := v.(bool)
+		log.Printf("[DEBUG] topic compaction is : %v", vs)
+		opts.Compaction = vs
+	}
+
+	log.Printf("[DEBUG] Creating Kafka topic %s", opts.Name)
+
+	_, _, createErr := client.Kafka.CreateTopic(kafkaID, opts)
+	if createErr != nil {
+		return diag.FromErr(createErr)
+	}
+
+	log.Printf("[DEBUG] Waiting for Kafka topic %s to be ready", opts.Name)
+
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{kafka.TopicStatuses.PENDING.ToString()},
+		Target:       []string{kafka.TopicStatuses.READY.ToString()},
+		Refresh:      topicCreationStateRefreshFunc(client, kafkaID, opts.Name, opts.Partitions),
+		Timeout:      time.Duration(config.KafkaTopicCreateTimeout) * time.Minute,
+		PollInterval: 5 * time.Second,
+	}
+
+	if _, err := stateConf.WaitForStateContext(ctx); err != nil {
+		return diag.Errorf("error waiting for topic to be ready on %s: %s", opts.Name, err.Error())
+	}
+
+	d.SetId(fmt.Sprintf("%s:%s", kafkaID, opts.Name))
+
+	return resourceHerokuxKafkaTopicRead(ctx, d, meta)
+}
+
+// topicCreationStateRefreshFunc checks if the topic is ready. 'Ready' state is determined by two things:
+//  1) the topic is present when retrieving from all topics
+//  2) the number of partitions matches the specified count.
+func topicCreationStateRefreshFunc(client *api.Client, kafkaID, topicName string, partitionCount int) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		topic, response, getErr := client.Kafka.GetTopicByName(kafkaID, topicName)
+		if getErr != nil {
+			if response.StatusCode == 404 {
+				// this means the topic hasn't been created just yet
+				return nil, kafka.TopicStatuses.PENDING.ToString(), nil
+			}
+			return nil, kafka.TopicStatuses.UNKNOWN.ToString(), getErr
+		}
+
+		if topic.GetPartitions() != partitionCount {
+			log.Printf("[DEBUG] topic created but partitions not provisioned. Count is %d", topic.GetPartitions())
+			return topic, kafka.TopicStatuses.PENDING.ToString(), nil
+		}
+
+		return topic, kafka.TopicStatuses.READY.ToString(), nil
+	}
+}
+
+func resourceHerokuxKafkaTopicRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*Config).API
+
+	result, parseErr := parseCompositeID(d.Id(), 2)
+	if parseErr != nil {
+		return diag.FromErr(parseErr)
+	}
+
+	kafkaID := result[0]
+	name := result[1]
+
+	topic, _, getErr := client.Kafka.GetTopicByName(kafkaID, name)
+	if getErr != nil {
+		return diag.FromErr(getErr)
+	}
+
+	// Convert the remote retention time from milliseconds to duration unless it is disabled.
+	var retentiontimeDuration string
+	if topic.GetRetentionTimeInMS() == 0 {
+		retentiontimeDuration = "disable"
+	} else {
+		var convErr error
+		retentiontimeDuration, convErr = kafka.ConvertMillisecondstoDuration(topic.GetRetentionTimeInMS())
+		if convErr != nil {
+			return diag.FromErr(convErr)
+		}
+	}
+
+	d.Set("name", topic.GetName())
+	d.Set("partitions", topic.GetPartitions())
+	d.Set("replication_factor", topic.GetReplicationFactor())
+	d.Set("retention_time", retentiontimeDuration)
+	d.Set("compaction", topic.GetCompaction())
+	d.Set("status", topic.GetStatus())
+	d.Set("cleanup_policy", topic.GetCleanupPolicy())
+
+	return nil
+}
+
+func resourceHerokuxKafkaTopicUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*Config)
+	client := config.API
+
+	opts := &kafka.TopicRequest{}
+	kafkaID := getKakfaID(d)
+	checkFuncs := make([]func(t *kafka.Topic) bool, 0)
+
+	if v, ok := d.GetOk("name"); ok {
+		vs := v.(string)
+		log.Printf("[DEBUG] topic name is : %v", vs)
+		opts.Name = vs
+	}
+
+	if v, ok := d.GetOk("compaction"); ok {
+		vs := v.(bool)
+		log.Printf("[DEBUG] topic compaction is : %v", vs)
+		opts.Compaction = vs
+	}
+
+	if v, ok := d.GetOk("retention_time"); ok {
+		duration := v.(string)
+		log.Printf("[DEBUG] topic retention_time (string) is : %v", duration)
+
+		// Convert the duration to milliseconds as that's what is supported by the API
+		// unless the attribute value is `disable`. If it is disable,
+		// then set the opts.RetentionTimeMS to nil.
+		var targetRetentionTime int
+		if duration == kafka.RetentionTimeDisableVal {
+			opts.RetentionTimeMS = nil
+			targetRetentionTime = 0
+			log.Printf("[DEBUG] topic new retention_time (int) is : %v", "nil")
+		} else {
+			ms, conErr := kafka.ConvertDurationToMilliseconds(duration)
+			if conErr != nil {
+				return diag.FromErr(conErr)
+			}
+			opts.RetentionTimeMS = &ms
+			targetRetentionTime = ms
+			log.Printf("[DEBUG] topic new retention_time (int) is : %v", ms)
+		}
+
+		// The API generally requires retention_time being set in the PUT request body but if there's an update,
+		// the resource needs to poll to check that the new retention time is applied correctly.
+		if ok := d.HasChange("retention_time"); ok {
+			// Setting checkFunc so the resource knows what to check for
+			checkFuncs = append(checkFuncs, func(t *kafka.Topic) bool {
+				if t.GetRetentionTimeInMS() == targetRetentionTime {
+					return true
+				}
+				return false
+			})
+		}
+	}
+
+	if ok := d.HasChange("replication_factor"); ok {
+		vs := d.Get("replication_factor").(int)
+		log.Printf("[DEBUG] topic new replication_factor is : %v", vs)
+		opts.ReplicationFactor = vs
+	}
+
+	log.Printf("[DEBUG] updating topic %s with %v", opts.Name, opts)
+
+	_, _, updateErr := client.Kafka.UpdateTopic(kafkaID, opts)
+	if updateErr != nil {
+		return diag.FromErr(updateErr)
+	}
+
+	log.Printf("[DEBUG] Waiting for Kafka topic %s to be updated", opts.Name)
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{kafka.TopicStatuses.UPDATING.ToString()},
+		Target:       []string{kafka.TopicStatuses.UPDATED.ToString()},
+		Refresh:      topicUpdateStateRefreshFunc(client, kafkaID, opts.Name, checkFuncs),
+		Timeout:      time.Duration(config.KafkaTopicCreateTimeout) * time.Minute,
+		PollInterval: 5 * time.Second,
+	}
+
+	if _, err := stateConf.WaitForStateContext(ctx); err != nil {
+		return diag.Errorf("error waiting for topic to be updated on %s: %s", opts.Name, err.Error())
+	}
+
+	log.Printf("[DEBUG] updated topic %s with %v", opts.Name, opts)
+
+	return resourceHerokuxKafkaTopicRead(ctx, d, meta)
+}
+
+// topicUpdateStateRefreshFunc checks if certain topic fields were updated remotely
+// by executing custom functions passed in as function argument.
+func topicUpdateStateRefreshFunc(client *api.Client, kafkaID, topicName string, checkFuncs []func(t *kafka.Topic) bool) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		topic, _, getErr := client.Kafka.GetTopicByName(kafkaID, topicName)
+		if getErr != nil {
+			return nil, kafka.TopicStatuses.UNKNOWN.ToString(), getErr
+		}
+
+		// Loop through all the checkFuncs. Return UPDATING if any of the functions return false
+		if checkFuncs != nil {
+			for _, cf := range checkFuncs {
+				if !cf(topic) {
+					log.Printf("[DEBUG] topic not updated yet")
+					return topic, kafka.TopicStatuses.UPDATING.ToString(), nil
+				}
+			}
+		}
+
+		return topic, kafka.TopicStatuses.UPDATED.ToString(), nil
+	}
+}
+
+func resourceHerokuxKafkaTopicDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*Config).API
+
+	result, parseErr := parseCompositeID(d.Id(), 2)
+	if parseErr != nil {
+		return diag.FromErr(parseErr)
+	}
+
+	kafkaID := result[0]
+	name := result[1]
+
+	log.Printf("[DEBUG] Deleting Kafka topic %s", name)
+
+	_, _, deleteErr := client.Kafka.DeleteTopic(kafkaID, name)
+	if deleteErr != nil {
+		return diag.FromErr(deleteErr)
+	}
+
+	log.Printf("[DEBUG] Deleted Kafka topic %s", name)
+
+	d.SetId("")
+
+	return nil
+}

--- a/herokux/resource_herokux_kafka_topic_test.go
+++ b/herokux/resource_herokux_kafka_topic_test.go
@@ -1,0 +1,231 @@
+package herokux
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"testing"
+)
+
+func TestAccHerokuxKafkaTopic_Basic(t *testing.T) {
+	kafkaID := testAccConfig.GetKafkaIDorSkip(t)
+	topicName := fmt.Sprintf("tftest-%s", acctest.RandString(15))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckHerokuxKafkaTopic_basic(kafkaID, topicName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"herokux_kafka_topic.foobar", "kafka_id", kafkaID),
+					resource.TestCheckResourceAttr(
+						"herokux_kafka_topic.foobar", "name", topicName),
+					resource.TestCheckResourceAttr(
+						"herokux_kafka_topic.foobar", "partitions", "8"),
+					resource.TestCheckResourceAttr(
+						"herokux_kafka_topic.foobar", "replication_factor", "3"),
+					resource.TestCheckResourceAttr(
+						"herokux_kafka_topic.foobar", "retention_time", "2d"),
+					resource.TestCheckResourceAttr(
+						"herokux_kafka_topic.foobar", "compaction", "true"),
+					resource.TestCheckResourceAttrSet(
+						"herokux_kafka_topic.foobar", "status"),
+					resource.TestCheckResourceAttrSet(
+						"herokux_kafka_topic.foobar", "cleanup_policy"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccHerokuxKafkaTopic_Simple(t *testing.T) {
+	kafkaID := testAccConfig.GetKafkaIDorSkip(t)
+	topicName := fmt.Sprintf("tftest-%s", acctest.RandString(15))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckHerokuxKafkaTopic_NoRetentionReplicationSpecified(kafkaID, topicName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"herokux_kafka_topic.foobar", "kafka_id", kafkaID),
+					resource.TestCheckResourceAttr(
+						"herokux_kafka_topic.foobar", "name", topicName),
+					resource.TestCheckResourceAttr(
+						"herokux_kafka_topic.foobar", "partitions", "8"),
+					resource.TestCheckResourceAttr(
+						"herokux_kafka_topic.foobar", "replication_factor", "3"),
+					resource.TestCheckResourceAttr(
+						"herokux_kafka_topic.foobar", "retention_time", "1d"),
+					resource.TestCheckResourceAttr(
+						"herokux_kafka_topic.foobar", "compaction", "false"),
+					resource.TestCheckResourceAttrSet(
+						"herokux_kafka_topic.foobar", "status"),
+					resource.TestCheckResourceAttrSet(
+						"herokux_kafka_topic.foobar", "cleanup_policy"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccHerokuxKafkaTopic_UpdatePlan(t *testing.T) {
+	kafkaID := testAccConfig.GetKafkaIDorSkip(t)
+	topicName := fmt.Sprintf("tftest-%s", acctest.RandString(15))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckHerokuxKafkaTopic_basic(kafkaID, topicName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"herokux_kafka_topic.foobar", "kafka_id", kafkaID),
+					resource.TestCheckResourceAttr(
+						"herokux_kafka_topic.foobar", "name", topicName),
+					resource.TestCheckResourceAttr(
+						"herokux_kafka_topic.foobar", "partitions", "8"),
+					resource.TestCheckResourceAttr(
+						"herokux_kafka_topic.foobar", "replication_factor", "3"),
+					resource.TestCheckResourceAttr(
+						"herokux_kafka_topic.foobar", "retention_time", "2d"),
+					resource.TestCheckResourceAttr(
+						"herokux_kafka_topic.foobar", "compaction", "true"),
+					resource.TestCheckResourceAttrSet(
+						"herokux_kafka_topic.foobar", "status"),
+					resource.TestCheckResourceAttrSet(
+						"herokux_kafka_topic.foobar", "cleanup_policy"),
+				),
+			},
+			{
+				Config: testAccCheckHerokuxKafkaTopic_updated(kafkaID, topicName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"herokux_kafka_topic.foobar", "kafka_id", kafkaID),
+					resource.TestCheckResourceAttr(
+						"herokux_kafka_topic.foobar", "name", topicName),
+					resource.TestCheckResourceAttr(
+						"herokux_kafka_topic.foobar", "partitions", "8"),
+					resource.TestCheckResourceAttr(
+						"herokux_kafka_topic.foobar", "replication_factor", "3"),
+					resource.TestCheckResourceAttr(
+						"herokux_kafka_topic.foobar", "retention_time", "95h"),
+					resource.TestCheckResourceAttr(
+						"herokux_kafka_topic.foobar", "compaction", "false"),
+					resource.TestCheckResourceAttrSet(
+						"herokux_kafka_topic.foobar", "status"),
+					resource.TestCheckResourceAttrSet(
+						"herokux_kafka_topic.foobar", "cleanup_policy"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccHerokuxKafkaTopic_DisableRetention(t *testing.T) {
+	kafkaID := testAccConfig.GetKafkaIDorSkip(t)
+	topicName := fmt.Sprintf("tftest-%s", acctest.RandString(15))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckHerokuxKafkaTopic_basic(kafkaID, topicName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"herokux_kafka_topic.foobar", "kafka_id", kafkaID),
+					resource.TestCheckResourceAttr(
+						"herokux_kafka_topic.foobar", "name", topicName),
+					resource.TestCheckResourceAttr(
+						"herokux_kafka_topic.foobar", "partitions", "8"),
+					resource.TestCheckResourceAttr(
+						"herokux_kafka_topic.foobar", "replication_factor", "3"),
+					resource.TestCheckResourceAttr(
+						"herokux_kafka_topic.foobar", "retention_time", "2d"),
+					resource.TestCheckResourceAttr(
+						"herokux_kafka_topic.foobar", "compaction", "true"),
+					resource.TestCheckResourceAttrSet(
+						"herokux_kafka_topic.foobar", "status"),
+					resource.TestCheckResourceAttrSet(
+						"herokux_kafka_topic.foobar", "cleanup_policy"),
+				),
+			},
+			{
+				Config: testAccCheckHerokuxKafkaTopic_retentionDisabled(kafkaID, topicName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"herokux_kafka_topic.foobar", "kafka_id", kafkaID),
+					resource.TestCheckResourceAttr(
+						"herokux_kafka_topic.foobar", "name", topicName),
+					resource.TestCheckResourceAttr(
+						"herokux_kafka_topic.foobar", "partitions", "8"),
+					resource.TestCheckResourceAttr(
+						"herokux_kafka_topic.foobar", "replication_factor", "3"),
+					resource.TestCheckResourceAttr(
+						"herokux_kafka_topic.foobar", "retention_time", "disable"),
+					resource.TestCheckResourceAttr(
+						"herokux_kafka_topic.foobar", "compaction", "true"),
+					resource.TestCheckResourceAttrSet(
+						"herokux_kafka_topic.foobar", "status"),
+					resource.TestCheckResourceAttrSet(
+						"herokux_kafka_topic.foobar", "cleanup_policy"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckHerokuxKafkaTopic_basic(kafkaID, name string) string {
+	return fmt.Sprintf(`
+resource "herokux_kafka_topic" "foobar" {
+	kafka_id = "%s"
+	name = "%s"
+	partitions = 8
+	replication_factor = 3
+	retention_time = "2d"
+	compaction = true
+}
+`, kafkaID, name)
+}
+
+func testAccCheckHerokuxKafkaTopic_NoRetentionReplicationSpecified(kafkaID, name string) string {
+	return fmt.Sprintf(`
+resource "herokux_kafka_topic" "foobar" {
+	kafka_id = "%s"
+	name = "%s"
+	partitions = 8
+}
+`, kafkaID, name)
+}
+
+func testAccCheckHerokuxKafkaTopic_updated(kafkaID, name string) string {
+	return fmt.Sprintf(`
+resource "herokux_kafka_topic" "foobar" {
+	kafka_id = "%s"
+	name = "%s"
+	partitions = 8
+	replication_factor = 3
+	retention_time = "95h"
+	compaction = false
+}
+`, kafkaID, name)
+}
+
+func testAccCheckHerokuxKafkaTopic_retentionDisabled(kafkaID, name string) string {
+	return fmt.Sprintf(`
+resource "herokux_kafka_topic" "foobar" {
+	kafka_id = "%s"
+	name = "%s"
+	partitions = 8
+	replication_factor = 3
+	retention_time = "disable"
+	compaction = true
+}
+`, kafkaID, name)
+}

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -111,3 +111,10 @@ Only a single `timeouts` block may be specified and it supports the following ar
 
   * `kafka_cg_delete_timeout` - (Optional) The number of minutes to wait for a Kafka consumer group to be deleted.
   Defaults to 10 minutes.
+
+  * `kafka_topic_create_timeout` - (Optional) The number of minutes to wait for a Kafka topic to ready. Ready state
+  is achieved when the topic itself is provisioned with the specified number of partitions.
+  Defaults to 10 minutes. Minimum required is 3 minutes.
+
+  * `kafka_topic_update_timeout` - (Optional) The number of minutes to wait for a Kafka topic to updated remotely.
+  Defaults to 10 minutes. Minimum required is 3 minutes.

--- a/website/docs/r/kafka_topic.html.markdown
+++ b/website/docs/r/kafka_topic.html.markdown
@@ -1,0 +1,104 @@
+---
+layout: "herokux"
+page_title: "HerokuX: herokux_kafka_topic"
+sidebar_current: "docs-herokux-resource-kafka-topic"
+description: |-
+  Provides a resource to manage a Kafka topic
+---
+
+# herokux\_kafka\_topic
+
+This resource manages topics in an existing Heroku Kafka instance.
+
+-> **IMPORTANT!**
+Design Kafka topics carefully. Parameters like retention or compaction can be changed relatively easily,
+and replication can be changed with some additional care, but partitions CANNOT currently be changed after creation.
+Compaction and time-based retention are mutually exclusive configurations for a given topic,
+though different topics within a cluster may have a mix of these configurations.
+
+### Resources
+Configuring Kafka topics is very dependent on your Kafka addon plan.
+Please refer to the following documentation when deciding how to configure a topic within the plan's limitations:
+- [Apache Kafka on Heroku](https://devcenter.heroku.com/articles/kafka-on-heroku)
+- [Apache Kafka on Heroku Plan Details](https://elements.heroku.com/addons/heroku-kafka)
+- [Multi-Tenant Apache Kafka on Heroku](https://devcenter.heroku.com/articles/multi-tenant-kafka-on-heroku#basic-plans)
+- [Apache Kafka on Heroku Add-on Migration](https://devcenter.heroku.com/articles/kafka-addon-migration)
+
+### Resource Timeouts
+This resource checks the status of a creation or update action.
+Both checks' default timeout is 10 minutes, which can be customized
+via the `timeouts.kafka_topic_create_timeout` and `timeouts.kafka_topic_update_timeout` in your `provider` block.
+
+For example:
+```hcl-terraform
+provider "herokux" {
+  timeouts {
+    kafka_topic_create_timeout = 15
+    kafka_topic_update_timeout = 15
+  }
+}
+```
+
+## Example Usage
+
+```hcl-terraform
+resource "herokux_kafka_topic" "foobar" {
+	kafka_id = "SOME_KAFKA_ID"
+	name = "my-cool-topic"
+	partitions = 8
+	replication_factor = 3
+	retention_time = "2d"
+	compaction = true
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `kafka_id` - (Required) `<string>` The UUID of an existing Kafka instance.
+
+* `name` - (Required) `<string>` The name of the topic. Alphanumeric characters, periods, underscores, and hyphens.
+Immutable after creation.
+
+* `partitions` - (Required) `<integer>` Number of partitions. Partitions are discrete subsets of a topic used to
+balance the concerns of parallelism and ordering. Increased numbers of partitions can increase the number
+of producers and consumers that can work on a given topic, increasing parallelism and throughput.
+
+* `replication_factor` - (Optional) `<integer>` The replication factor for the topic. The default & minimum value is 3.
+The upper limit is the number of brokers available for your Kafka plan.
+
+* `retention_time` - (Optional) `<string>` How long to keep messages before they are cleaned up and removed.
+Please note the following:
+    * Default and minimum value is "1d" or equivalent in other units of duration. Each Heroku Kafka plan has different maximum retention times.
+    * Acceptable values follow this format: `<NUMERICAL_DIGITS><ms|s|m|h|d|w>`. For example:
+        * "6w" is six weeks.
+        * "13d" is thirteen days.
+        * "12000m" is twelve thousand minutes.
+    * If using a retention time that can be expressed in two different units of duration, please use the larger unit of duration.
+    For example, you must use "2w" over "14d".
+    * Depending on the Kafka plan, to disable retention time, specify "disable' as this attribute's value.
+    * `retention_time` is required when `compaction` is disabled. Retention time must be set for multi-tenanted plans.
+
+* `compaction` - (Optional) `<boolean>` Enable log compaction. This configuration changes the semantics of a topic such
+that it keeps only the most recent message for a given key, tombstoning any predecessor.
+This allows for the creation of a value-stream, or table-like view of data,
+and is a very powerful construct in modeling your data and systems. Defaults is `false`.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `status` - (Optional) `<string>` Status of the topic.
+
+* `cleanup_policy` - (Optional) `<string>` The current cleanup policy for the topic.
+
+## Import
+
+An existing topic can be imported using a composite value of the Kafka ID and topic name
+separated by a colon.
+
+For example:
+```shell script
+$ terraform import herokux_kafka_topic.foobar "<KAFKA_ID>:<TOPIC_NAME>"
+```

--- a/website/herokux.erb
+++ b/website/herokux.erb
@@ -29,6 +29,10 @@
                   <a href="/docs/providers/herokux/r/kafka_consumer_group.html">herokux_kafka_consumer_group</a>
                 </li>
 
+                <li<%= sidebar_current("docs-herokux-resource-kafka-topic") %>>
+                  <a href="/docs/providers/herokux/r/kafka_topic.html">herokux_kafka_topic</a>
+                </li>
+
                 <li<%= sidebar_current("docs-herokux-resource-postgres-mtls") %>>
                   <a href="/docs/providers/herokux/r/postgres_mtls.html">herokux_postgres_mtls</a>
                 </li>


### PR DESCRIPTION
## TODO:
- [x] Add `update`
- [x] Add docs
- [x] Add tests
- [x] Figure out how to handle retention disabling

## TIDBITS
- Topic name is not updateable.
- `retention_time_ms` needs to be in the PUT body for multi-tenanted plans.
- `partitions` is not editable after creation.
- Retention is required when compaction is disabled.
- Retention time must be set for multi-tenanted plans.
- The replication factor of the topic. Must be 3 for this plan.
- Retention time min value is 24 hours. Max depends on the plan.
- it takes time for the topics to be created and the partitions ready

https://devcenter.heroku.com/articles/multi-tenant-kafka-on-heroku#basic-plans