### PR TITLE
New resource: herokux_privatelink

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -16,7 +16,7 @@ const (
 	DefaultMetricAPIBaseURL = "https://api.metrics.heroku.com"
 
 	// DefaultPostgresAPIBaseURL is the default base URL for Postgres related APIs.
-	DefaultPostgresAPIBaseURL = "https://postgres-api.heroku.com/postgres/v0"
+	DefaultPostgresAPIBaseURL = "https://postgres-api.heroku.com"
 
 	// DefaultKafkaAPIBaseURL is the default base URL for Kafka related APIs.
 	DefaultKafkaAPIBaseURL = "https://postgres-api.heroku.com/data/kafka/v0"

--- a/api/api.go
+++ b/api/api.go
@@ -18,9 +18,6 @@ const (
 	// DefaultPostgresAPIBaseURL is the default base URL for Postgres related APIs.
 	DefaultPostgresAPIBaseURL = "https://postgres-api.heroku.com"
 
-	// DefaultKafkaAPIBaseURL is the default base URL for Kafka related APIs.
-	DefaultKafkaAPIBaseURL = "https://postgres-api.heroku.com/data/kafka/v0"
-
 	// DefaultDataBaseURL is the default base URL for the Data Graph APIs.
 	DefaultDataBaseURL = "https://data-api.heroku.com"
 
@@ -51,7 +48,7 @@ func New(opts ...config2.Option) (*Client, error) {
 	config := &config2.Config{
 		MetricsBaseURL:    DefaultMetricAPIBaseURL,
 		PostgresBaseURL:   DefaultPostgresAPIBaseURL,
-		KafkaBaseURL:      DefaultKafkaAPIBaseURL,
+		KafkaBaseURL:      DefaultPostgresAPIBaseURL, // The Kafka API endpoints use the same base URL as postgres endpoints.
 		DataBaseURL:       DefaultDataBaseURL,
 		UserAgent:         DefaultUserAgent,
 		APIToken:          "",

--- a/api/data/types.go
+++ b/api/data/types.go
@@ -9,11 +9,13 @@ var PrivatelinkStatuses = struct {
 	OPERATIONAL    PrivatelinkStatus
 	DEPROVISIONING PrivatelinkStatus
 	DEPROVISIONED  PrivatelinkStatus
+	UNKNOWN        PrivatelinkStatus
 }{
 	PROVISIONING:   "Provisioning",
 	OPERATIONAL:    "Operational",
 	DEPROVISIONING: "Deprovisioning",
 	DEPROVISIONED:  "Deprovisioned", // Status is set to this even though the UI says deprovisioning. Must wait for 404.
+	UNKNOWN:        "Unknown",
 }
 
 // ToString is a helper method to return the string of a PrivatelinkStatus.
@@ -28,9 +30,11 @@ type PrivatelinkAllowedAccountStatus string
 var PrivatelinkAllowedAccountStatuses = struct {
 	PROVISIONING PrivatelinkAllowedAccountStatus
 	ACTIVE       PrivatelinkAllowedAccountStatus
+	UNKNOWN      PrivatelinkAllowedAccountStatus
 }{
 	PROVISIONING: "Provisioning",
 	ACTIVE:       "Active",
+	UNKNOWN:      "Unknown",
 }
 
 // ToString is a helper method to return the string of a PrivatelinkAllowedAccountStatus.

--- a/api/data/types.go
+++ b/api/data/types.go
@@ -20,3 +20,20 @@ var PrivatelinkStatuses = struct {
 func (s PrivatelinkStatus) ToString() string {
 	return string(s)
 }
+
+// PrivatelinkAllowedAccountStatus represents the status of a privatelink allowed account.
+type PrivatelinkAllowedAccountStatus string
+
+// PrivatelinkAllowedAccountStatuses represent all statuses pertaining to the lifecycle of a privatelink allowed account.
+var PrivatelinkAllowedAccountStatuses = struct {
+	PROVISIONING PrivatelinkAllowedAccountStatus
+	ACTIVE       PrivatelinkAllowedAccountStatus
+}{
+	PROVISIONING: "Provisioning",
+	ACTIVE:       "Active",
+}
+
+// ToString is a helper method to return the string of a PrivatelinkAllowedAccountStatus.
+func (s PrivatelinkAllowedAccountStatus) ToString() string {
+	return string(s)
+}

--- a/api/kafka/cluster.go
+++ b/api/kafka/cluster.go
@@ -91,7 +91,7 @@ type ClusterLimitsDataSize struct {
 // Get retrieves information about a Kafka cluster.
 func (k *Kafka) Get(clusterID string) (*Cluster, *simpleresty.Response, error) {
 	var result *Cluster
-	urlStr := k.http.RequestURL("/clusters/%s", clusterID)
+	urlStr := k.http.RequestURL("/data/kafka/v0/clusters/%s", clusterID)
 
 	// Execute the request
 	response, getErr := k.http.Get(urlStr, &result, nil)

--- a/api/kafka/consumer_groups.go
+++ b/api/kafka/consumer_groups.go
@@ -32,7 +32,7 @@ type consumerGroupBody struct {
 // ListConsumerGroups returns a list of all consumer groups.
 func (k *Kafka) ListConsumerGroups(clusterID string) (*ConsumerGroups, *simpleresty.Response, error) {
 	var result *ConsumerGroups
-	urlStr := k.http.RequestURL("/clusters/%s/consumer_groups", clusterID)
+	urlStr := k.http.RequestURL("/data/kafka/v0/clusters/%s/consumer_groups", clusterID)
 
 	// Execute the request
 	response, getErr := k.http.Get(urlStr, &result, nil)
@@ -61,7 +61,7 @@ func (k *Kafka) GetConsumerGroupByName(clusterID, groupName string) (*ConsumerGr
 // The group is not ready for use until it appears in the LIST response.
 func (k *Kafka) CreateConsumerGroup(clusterID string, opts *consumerGroupRequest) (*Response, *simpleresty.Response, error) {
 	var result *Response
-	urlStr := k.http.RequestURL("/clusters/%s/consumer_groups", clusterID)
+	urlStr := k.http.RequestURL("/data/kafka/v0/clusters/%s/consumer_groups", clusterID)
 
 	reqBody := &consumerGroupBody{
 		ConsumerGroup: opts,
@@ -76,7 +76,7 @@ func (k *Kafka) CreateConsumerGroup(clusterID string, opts *consumerGroupRequest
 // DeleteConsumerGroup deletes an existing consumer group.
 func (k *Kafka) DeleteConsumerGroup(clusterID string, opts *consumerGroupRequest) (*Response, *simpleresty.Response, error) {
 	var result *Response
-	urlStr := k.http.RequestURL("/clusters/%s/consumer_groups", clusterID)
+	urlStr := k.http.RequestURL("/data/kafka/v0/clusters/%s/consumer_groups", clusterID)
 
 	reqBody := &consumerGroupBody{
 		ConsumerGroup: opts,

--- a/api/kafka/topics.go
+++ b/api/kafka/topics.go
@@ -63,7 +63,7 @@ type topicRequestBody struct {
 // ListTopics returns a list of cluster topics.
 func (k *Kafka) ListTopics(clusterID string) (*Topics, *simpleresty.Response, error) {
 	var result *Topics
-	urlStr := k.http.RequestURL("/clusters/%s/topics", clusterID)
+	urlStr := k.http.RequestURL("/data/kafka/v0/clusters/%s/topics", clusterID)
 
 	// Execute the request
 	response, getErr := k.http.Get(urlStr, &result, nil)
@@ -97,7 +97,7 @@ func (k *Kafka) GetTopicByName(clusterID, topicName string) (*Topic, *simplerest
 // CreateTopic creates a cluster topic.
 func (k *Kafka) CreateTopic(clusterID string, opts *TopicRequest) (*Response, *simpleresty.Response, error) {
 	var result *Response
-	urlStr := k.http.RequestURL("/clusters/%s/topics", clusterID)
+	urlStr := k.http.RequestURL("/data/kafka/v0/clusters/%s/topics", clusterID)
 	reqBody := &topicRequestBody{Topic: opts}
 
 	// Execute the request
@@ -109,7 +109,7 @@ func (k *Kafka) CreateTopic(clusterID string, opts *TopicRequest) (*Response, *s
 // UpdateTopic updates an existing Kafka topic.
 func (k *Kafka) UpdateTopic(clusterID string, opts *TopicRequest) (*Response, *simpleresty.Response, error) {
 	var result *Response
-	urlStr := k.http.RequestURL("/clusters/%s/topics/%s", clusterID, opts.Name)
+	urlStr := k.http.RequestURL("/data/kafka/v0/clusters/%s/topics/%s", clusterID, opts.Name)
 	reqBody := &topicRequestBody{Topic: opts}
 
 	// Execute the request
@@ -122,7 +122,7 @@ func (k *Kafka) UpdateTopic(clusterID string, opts *TopicRequest) (*Response, *s
 func (k *Kafka) DeleteTopic(clusterID, topicName string) (*Response, *simpleresty.Response, error) {
 	var result *Response
 
-	urlStr := k.http.RequestURL("/clusters/%s/topics/%s", clusterID, topicName)
+	urlStr := k.http.RequestURL("/data/kafka/v0/clusters/%s/topics/%s", clusterID, topicName)
 
 	// Execute the request
 	response, createErr := k.http.Delete(urlStr, &result, nil)

--- a/api/postgres/mtls.go
+++ b/api/postgres/mtls.go
@@ -20,7 +20,7 @@ type MTLS struct {
 // Once the configuration is ready, "status" changes to "Operational".
 func (p *Postgres) ProvisionMTLS(nameOrID string) (*MTLS, *simpleresty.Response, error) {
 	var result *MTLS
-	urlStr := p.http.RequestURL("/databases/%s/tls-endpoint", nameOrID)
+	urlStr := p.http.RequestURL("/postgres/v0/databases/%s/tls-endpoint", nameOrID)
 
 	// Execute the request
 	response, createErr := p.http.Post(urlStr, &result, nil)
@@ -49,7 +49,7 @@ func (p *Postgres) IsMTLSReady(nameOrID string) (bool, MTLSConfigStatus, error) 
 // Returns 202 if request is successful with a 'status' of 'Deprovisioning'.
 func (p *Postgres) DeprovisionMTLS(nameOrID string) (*MTLS, *simpleresty.Response, error) {
 	var result *MTLS
-	urlStr := p.http.RequestURL("/databases/%s/tls-endpoint", nameOrID)
+	urlStr := p.http.RequestURL("/postgres/v0/databases/%s/tls-endpoint", nameOrID)
 
 	// Execute the request
 	response, deleteErr := p.http.Delete(urlStr, &result, nil)
@@ -60,7 +60,7 @@ func (p *Postgres) DeprovisionMTLS(nameOrID string) (*MTLS, *simpleresty.Respons
 // GetMTLS retrieves the MTLS configuration for a database.
 func (p *Postgres) GetMTLS(nameOrID string) (*MTLS, *simpleresty.Response, error) {
 	var result *MTLS
-	urlStr := p.http.RequestURL("/databases/%s/tls-endpoint", nameOrID)
+	urlStr := p.http.RequestURL("/postgres/v0/databases/%s/tls-endpoint", nameOrID)
 
 	// Execute the request
 	response, getErr := p.http.Get(urlStr, &result, nil)

--- a/api/postgres/mtls_cert.go
+++ b/api/postgres/mtls_cert.go
@@ -24,7 +24,7 @@ type MTLSCert struct {
 // Furthermore, this endpoint also returns certificates that were disabled.
 func (p *Postgres) ListMTLSCerts(dbNameOrID string) ([]*MTLSCert, *simpleresty.Response, error) {
 	var result []*MTLSCert
-	urlStr := p.http.RequestURL("/databases/%s/tls-endpoint/certificates", dbNameOrID)
+	urlStr := p.http.RequestURL("/postgres/v0/databases/%s/tls-endpoint/certificates", dbNameOrID)
 
 	// Execute the request
 	response, getErr := p.http.Get(urlStr, &result, nil)
@@ -37,7 +37,7 @@ func (p *Postgres) ListMTLSCerts(dbNameOrID string) ([]*MTLSCert, *simpleresty.R
 // This endpoint returns a 404 if you retrieve a certificate that has been disabled/deleted.
 func (p *Postgres) GetMTLSCert(dbNameOrID, certID string) (*MTLSCert, *simpleresty.Response, error) {
 	var result *MTLSCert
-	urlStr := p.http.RequestURL("/databases/%s/tls-endpoint/certificates/%s", dbNameOrID, certID)
+	urlStr := p.http.RequestURL("/postgres/v0/databases/%s/tls-endpoint/certificates/%s", dbNameOrID, certID)
 
 	// Execute the request
 	response, getErr := p.http.Get(urlStr, &result, nil)
@@ -51,7 +51,7 @@ func (p *Postgres) GetMTLSCert(dbNameOrID, certID string) (*MTLSCert, *simpleres
 // the certificate is ready for use.
 func (p *Postgres) CreateMTLSCert(dbNameOrID string) (*MTLSCert, *simpleresty.Response, error) {
 	var result *MTLSCert
-	urlStr := p.http.RequestURL("/databases/%s/tls-endpoint/certificates", dbNameOrID)
+	urlStr := p.http.RequestURL("/postgres/v0/databases/%s/tls-endpoint/certificates", dbNameOrID)
 
 	// Execute the request
 	response, createErr := p.http.Post(urlStr, &result, nil)
@@ -65,7 +65,7 @@ func (p *Postgres) CreateMTLSCert(dbNameOrID string) (*MTLSCert, *simpleresty.Re
 // Upon deletion, the target certificate has a status of 'disabling'.
 func (p *Postgres) DeleteMTLSCert(dbNameOrID, certID string) (*MTLSCert, *simpleresty.Response, error) {
 	var result *MTLSCert
-	urlStr := p.http.RequestURL("/databases/%s/tls-endpoint/certificates/%s", dbNameOrID, certID)
+	urlStr := p.http.RequestURL("/postgres/v0/databases/%s/tls-endpoint/certificates/%s", dbNameOrID, certID)
 
 	// Execute the request
 	response, deleteErr := p.http.Delete(urlStr, &result, nil)

--- a/api/postgres/mtls_iprule.go
+++ b/api/postgres/mtls_iprule.go
@@ -23,7 +23,7 @@ type MTLSIPRuleRequest struct {
 
 func (p *Postgres) ListMTLSIPRules(dbNameOrID string) ([]*MTLSIPRule, *simpleresty.Response, error) {
 	var result []*MTLSIPRule
-	urlStr := p.http.RequestURL("/databases/%s/tls-endpoint/ip-rules", dbNameOrID)
+	urlStr := p.http.RequestURL("/postgres/v0/databases/%s/tls-endpoint/ip-rules", dbNameOrID)
 
 	// Execute the request
 	response, getErr := p.http.Get(urlStr, &result, nil)
@@ -33,7 +33,7 @@ func (p *Postgres) ListMTLSIPRules(dbNameOrID string) ([]*MTLSIPRule, *simpleres
 
 func (p *Postgres) GetMTLSIPRule(dbNameOrID, ipRuleID string) (*MTLSIPRule, *simpleresty.Response, error) {
 	var result *MTLSIPRule
-	urlStr := p.http.RequestURL("/databases/%s/tls-endpoint/ip-rules/%s", dbNameOrID, ipRuleID)
+	urlStr := p.http.RequestURL("/postgres/v0/databases/%s/tls-endpoint/ip-rules/%s", dbNameOrID, ipRuleID)
 
 	// Execute the request
 	response, getErr := p.http.Get(urlStr, &result, nil)
@@ -43,7 +43,7 @@ func (p *Postgres) GetMTLSIPRule(dbNameOrID, ipRuleID string) (*MTLSIPRule, *sim
 
 func (p *Postgres) CreateMTLSIPRule(dbNameOrID string, opts *MTLSIPRuleRequest) (*MTLSIPRule, *simpleresty.Response, error) {
 	var result *MTLSIPRule
-	urlStr := p.http.RequestURL("/databases/%s/tls-endpoint/ip-rules", dbNameOrID)
+	urlStr := p.http.RequestURL("/postgres/v0/databases/%s/tls-endpoint/ip-rules", dbNameOrID)
 
 	// Execute the request
 	response, createErr := p.http.Post(urlStr, &result, opts)
@@ -52,7 +52,7 @@ func (p *Postgres) CreateMTLSIPRule(dbNameOrID string, opts *MTLSIPRuleRequest) 
 }
 
 func (p *Postgres) DeleteMTLSIPRule(dbNameOrID, ipRuleID string) (*simpleresty.Response, error) {
-	urlStr := p.http.RequestURL("/databases/%s/tls-endpoint/ip-rules/%s", dbNameOrID, ipRuleID)
+	urlStr := p.http.RequestURL("/postgres/v0/databases/%s/tls-endpoint/ip-rules/%s", dbNameOrID, ipRuleID)
 
 	// Execute the request
 	response, deleteErr := p.http.Delete(urlStr, nil, nil)

--- a/api/postgres/mtls_iprule.go
+++ b/api/postgres/mtls_iprule.go
@@ -21,6 +21,7 @@ type MTLSIPRuleRequest struct {
 	Description string `json:"description,omitempty"`
 }
 
+// ListMTLSIPRules returns all IP rules.
 func (p *Postgres) ListMTLSIPRules(dbNameOrID string) ([]*MTLSIPRule, *simpleresty.Response, error) {
 	var result []*MTLSIPRule
 	urlStr := p.http.RequestURL("/postgres/v0/databases/%s/tls-endpoint/ip-rules", dbNameOrID)
@@ -31,6 +32,7 @@ func (p *Postgres) ListMTLSIPRules(dbNameOrID string) ([]*MTLSIPRule, *simpleres
 	return result, response, getErr
 }
 
+// GetMTLSIPRule returns a single IP rule.
 func (p *Postgres) GetMTLSIPRule(dbNameOrID, ipRuleID string) (*MTLSIPRule, *simpleresty.Response, error) {
 	var result *MTLSIPRule
 	urlStr := p.http.RequestURL("/postgres/v0/databases/%s/tls-endpoint/ip-rules/%s", dbNameOrID, ipRuleID)
@@ -41,6 +43,7 @@ func (p *Postgres) GetMTLSIPRule(dbNameOrID, ipRuleID string) (*MTLSIPRule, *sim
 	return result, response, getErr
 }
 
+// CreateMTLSIPRule creates an IP rule.
 func (p *Postgres) CreateMTLSIPRule(dbNameOrID string, opts *MTLSIPRuleRequest) (*MTLSIPRule, *simpleresty.Response, error) {
 	var result *MTLSIPRule
 	urlStr := p.http.RequestURL("/postgres/v0/databases/%s/tls-endpoint/ip-rules", dbNameOrID)
@@ -51,6 +54,7 @@ func (p *Postgres) CreateMTLSIPRule(dbNameOrID string, opts *MTLSIPRuleRequest) 
 	return result, response, createErr
 }
 
+// DeleteMTLSIPRule deletes an IP rule.
 func (p *Postgres) DeleteMTLSIPRule(dbNameOrID, ipRuleID string) (*simpleresty.Response, error) {
 	urlStr := p.http.RequestURL("/postgres/v0/databases/%s/tls-endpoint/ip-rules/%s", dbNameOrID, ipRuleID)
 

--- a/api/postgres/postgres-accessors.go
+++ b/api/postgres/postgres-accessors.go
@@ -171,3 +171,143 @@ func (m *MTLSIPRule) GetUpdatedAt() time.Time {
 	}
 	return *m.UpdatedAt
 }
+
+// GetAddon returns the Addon field.
+func (p *Privatelink) GetAddon() *PrivatelinkAddon {
+	if p == nil {
+		return nil
+	}
+	return p.Addon
+}
+
+// HasAllowedAccounts checks if Privatelink has any AllowedAccounts.
+func (p *Privatelink) HasAllowedAccounts() bool {
+	if p == nil || p.AllowedAccounts == nil {
+		return false
+	}
+	if len(p.AllowedAccounts) == 0 {
+		return false
+	}
+	return true
+}
+
+// GetApp returns the App field.
+func (p *Privatelink) GetApp() *PrivatelinkApp {
+	if p == nil {
+		return nil
+	}
+	return p.App
+}
+
+// HasConnections checks if Privatelink has any Connections.
+func (p *Privatelink) HasConnections() bool {
+	if p == nil || p.Connections == nil {
+		return false
+	}
+	if len(p.Connections) == 0 {
+		return false
+	}
+	return true
+}
+
+// GetServiceName returns the ServiceName field if it's non-nil, zero value otherwise.
+func (p *Privatelink) GetServiceName() string {
+	if p == nil || p.ServiceName == nil {
+		return ""
+	}
+	return *p.ServiceName
+}
+
+// HasWhitelistedAccounts checks if Privatelink has any WhitelistedAccounts.
+func (p *Privatelink) HasWhitelistedAccounts() bool {
+	if p == nil || p.WhitelistedAccounts == nil {
+		return false
+	}
+	if len(p.WhitelistedAccounts) == 0 {
+		return false
+	}
+	return true
+}
+
+// GetName returns the Name field if it's non-nil, zero value otherwise.
+func (p *PrivatelinkAddon) GetName() string {
+	if p == nil || p.Name == nil {
+		return ""
+	}
+	return *p.Name
+}
+
+// GetUUID returns the UUID field if it's non-nil, zero value otherwise.
+func (p *PrivatelinkAddon) GetUUID() string {
+	if p == nil || p.UUID == nil {
+		return ""
+	}
+	return *p.UUID
+}
+
+// GetAccountID returns the AccountID field if it's non-nil, zero value otherwise.
+func (p *PrivatelinkAllowedAccounts) GetAccountID() string {
+	if p == nil || p.AccountID == nil {
+		return ""
+	}
+	return *p.AccountID
+}
+
+// GetARN returns the ARN field if it's non-nil, zero value otherwise.
+func (p *PrivatelinkAllowedAccounts) GetARN() string {
+	if p == nil || p.ARN == nil {
+		return ""
+	}
+	return *p.ARN
+}
+
+// GetName returns the Name field if it's non-nil, zero value otherwise.
+func (p *PrivatelinkApp) GetName() string {
+	if p == nil || p.Name == nil {
+		return ""
+	}
+	return *p.Name
+}
+
+// GetEndpointID returns the EndpointID field if it's non-nil, zero value otherwise.
+func (p *PrivatelinkConnections) GetEndpointID() string {
+	if p == nil || p.EndpointID == nil {
+		return ""
+	}
+	return *p.EndpointID
+}
+
+// GetHostname returns the Hostname field if it's non-nil, zero value otherwise.
+func (p *PrivatelinkConnections) GetHostname() string {
+	if p == nil || p.Hostname == nil {
+		return ""
+	}
+	return *p.Hostname
+}
+
+// GetOwnerARN returns the OwnerARN field if it's non-nil, zero value otherwise.
+func (p *PrivatelinkConnections) GetOwnerARN() string {
+	if p == nil || p.OwnerARN == nil {
+		return ""
+	}
+	return *p.OwnerARN
+}
+
+// GetStatus returns the Status field if it's non-nil, zero value otherwise.
+func (p *PrivatelinkConnections) GetStatus() string {
+	if p == nil || p.Status == nil {
+		return ""
+	}
+	return *p.Status
+}
+
+// HasAllowedAccounts checks if PrivatelinkRequest has any AllowedAccounts.
+func (p *PrivatelinkRequest) HasAllowedAccounts() bool {
+	if p == nil || p.AllowedAccounts == nil {
+		return false
+	}
+	if len(p.AllowedAccounts) == 0 {
+		return false
+	}
+	return true
+}

--- a/api/postgres/privatelink.go
+++ b/api/postgres/privatelink.go
@@ -11,7 +11,7 @@ import (
 type Privatelink struct {
 	App                 *PrivatelinkApp               `json:"app,omitempty"`
 	Addon               *PrivatelinkAddon             `json:"addon,omitempty"`
-	Status              *data.PrivatelinkStatus       `json:"status,omitempty"`
+	Status              data.PrivatelinkStatus        `json:"status,omitempty"`
 	ServiceName         *string                       `json:"service_name,omitempty"`
 	AllowedAccounts     []*PrivatelinkAllowedAccounts `json:"allowed_accounts,omitempty"`
 	WhitelistedAccounts []*PrivatelinkAllowedAccounts `json:"whitelisted_accounts,omitempty"`
@@ -20,9 +20,9 @@ type Privatelink struct {
 
 // PrivatelinkAllowedAccounts represents AWS accounts granted access to a privatelink.
 type PrivatelinkAllowedAccounts struct {
-	AccountID *string                               `json:"account_id,omitempty"`
-	ARN       *string                               `json:"arn,omitempty"`
-	Status    *data.PrivatelinkAllowedAccountStatus `json:"status,omitempty"`
+	AccountID *string                              `json:"account_id,omitempty"`
+	ARN       *string                              `json:"arn,omitempty"`
+	Status    data.PrivatelinkAllowedAccountStatus `json:"status,omitempty"`
 }
 
 // PrivatelinkConnections represents connections between Heroku postgres and AWS resources.
@@ -98,6 +98,8 @@ func (p *Postgres) RemovePrivatelinkAllowedAccounts(addonID string, opts *Privat
 }
 
 // AddPrivatelinkAllowedAccounts adds one more allowed accounts to a privatelink.
+//
+// Adding the same allowed account ID while the ID already exists results in a 202 "no-operation".
 //
 // Warning: the UI may become a bit wonky until the allowed account becomes `Active`.
 func (p *Postgres) AddPrivatelinkAllowedAccounts(addonID string, opts *PrivatelinkRequest) (*Privatelink, *simpleresty.Response, error) {

--- a/api/postgres/privatelink.go
+++ b/api/postgres/privatelink.go
@@ -1,0 +1,111 @@
+package postgres
+
+import (
+	"github.com/davidji99/simpleresty"
+	"github.com/davidji99/terraform-provider-herokux/api/data"
+)
+
+// Privatelink represents a connection between a Heroku postgres and AWS resources.
+//
+// The fields `AllowedAccounts` and `WhitelistedAccounts` are set to the same values.
+type Privatelink struct {
+	App                 *PrivatelinkApp               `json:"app,omitempty"`
+	Addon               *PrivatelinkAddon             `json:"addon,omitempty"`
+	Status              *data.PrivatelinkStatus       `json:"status,omitempty"`
+	ServiceName         *string                       `json:"service_name,omitempty"`
+	AllowedAccounts     []*PrivatelinkAllowedAccounts `json:"allowed_accounts,omitempty"`
+	WhitelistedAccounts []*PrivatelinkAllowedAccounts `json:"whitelisted_accounts,omitempty"`
+	Connections         []*PrivatelinkConnections     `json:"connections,omitempty"`
+}
+
+// PrivatelinkAllowedAccounts represents AWS accounts granted access to a privatelink.
+type PrivatelinkAllowedAccounts struct {
+	AccountID *string                               `json:"account_id,omitempty"`
+	ARN       *string                               `json:"arn,omitempty"`
+	Status    *data.PrivatelinkAllowedAccountStatus `json:"status,omitempty"`
+}
+
+// PrivatelinkConnections represents connections between Heroku postgres and AWS resources.
+type PrivatelinkConnections struct {
+	EndpointID *string `json:"endpoint_id,omitempty"`
+	Hostname   *string `json:"hostname,omitempty"`
+	OwnerARN   *string `json:"owner_arn,omitempty"`
+	Status     *string `json:"status,omitempty"`
+}
+
+// PrivatelinkApp represents the app hosting the addon that's has privatelink enabled.
+type PrivatelinkApp struct {
+	Name *string `json:"name,omitempty"`
+}
+
+// PrivatelinkAddon represents the addon that's being provisioned a privatelink.
+type PrivatelinkAddon struct {
+	Name *string `json:"name,omitempty"`
+	UUID *string `json:"uuid,omitempty"`
+}
+
+// PrivatelinkRequest represents a request to create or update privatelink.
+type PrivatelinkRequest struct {
+	AllowedAccounts []string `json:"allowed_accounts,omitempty"`
+}
+
+// CreatePrivatelink creates a privatelink for a Heroku postgres, redis, or kafka addon.
+func (p *Postgres) CreatePrivatelink(addonID string, opts *PrivatelinkRequest) (*Privatelink, *simpleresty.Response, error) {
+	var result *Privatelink
+	urlStr := p.http.RequestURL("/private-link/v0/databases/%s", addonID)
+
+	// Execute the request
+	response, createErr := p.http.Post(urlStr, &result, opts)
+
+	return result, response, createErr
+}
+
+// GetPrivatelink gets information about a privatelink for a Heroku postgres, redis, or kafka addon.
+func (p *Postgres) GetPrivatelink(addonID string) (*Privatelink, *simpleresty.Response, error) {
+	var result *Privatelink
+	urlStr := p.http.RequestURL("/private-link/v0/databases/%s", addonID)
+
+	// Execute the request
+	response, getErr := p.http.Get(urlStr, &result, nil)
+
+	return result, response, getErr
+}
+
+// DeletePrivatelink deletes a privatelink for a Heroku postgres, redis, or kafka addon.
+//
+// A successful DELETE requests results in the `status` set to Deprovisioned.
+// However, the UI will show "deprovisioning" so user needs to use `GetPrivatelink` method in a loop
+// until the GET request returns a `404`.
+func (p *Postgres) DeletePrivatelink(addonID string) (*Privatelink, *simpleresty.Response, error) {
+	var result *Privatelink
+	urlStr := p.http.RequestURL("/private-link/v0/databases/%s", addonID)
+
+	// Execute the request
+	response, deleteErr := p.http.Delete(urlStr, &result, nil)
+
+	return result, response, deleteErr
+}
+
+// RemovePrivatelinkAllowedAccounts removes one or more allowed accounts from a private link.
+func (p *Postgres) RemovePrivatelinkAllowedAccounts(addonID string, opts *PrivatelinkRequest) (*Privatelink, *simpleresty.Response, error) {
+	var result *Privatelink
+	urlStr := p.http.RequestURL("/private-link/v0/databases/%s/allowed_accounts", addonID)
+
+	// Execute the request
+	response, patchErr := p.http.Patch(urlStr, &result, opts)
+
+	return result, response, patchErr
+}
+
+// AddPrivatelinkAllowedAccounts adds one more allowed accounts to a privatelink.
+//
+// Warning: the UI may become a bit wonky until the allowed account becomes `Active`.
+func (p *Postgres) AddPrivatelinkAllowedAccounts(addonID string, opts *PrivatelinkRequest) (*Privatelink, *simpleresty.Response, error) {
+	var result *Privatelink
+	urlStr := p.http.RequestURL("/private-link/v0/databases/%s/allowed_accounts", addonID)
+
+	// Execute the request
+	response, patchErr := p.http.Put(urlStr, &result, opts)
+
+	return result, response, patchErr
+}

--- a/helper/test/config.go
+++ b/helper/test/config.go
@@ -12,6 +12,7 @@ type TestConfigKey int
 
 const (
 	TestConfigHerokuxAPIKey TestConfigKey = iota
+	TestConfigAddonID
 	TestConfigAppID
 	TestConfigDatabaseName
 	TestConfigKafkaID
@@ -20,6 +21,7 @@ const (
 
 var testConfigKeyToEnvName = map[TestConfigKey]string{
 	TestConfigHerokuxAPIKey:     "HEROKU_API_KEY",
+	TestConfigAddonID:           "HEROKUX_ADDON_ID",
 	TestConfigAppID:             "HEROKUX_APP_ID",
 	TestConfigDatabaseName:      "HEROKUX_DB_NAME",
 	TestConfigKafkaID:           "HEROKUX_KAFKA_ID",
@@ -72,6 +74,10 @@ func (t *TestConfig) SkipUnlessAccTest(testing *testing.T) {
 	if val == "" {
 		testing.Skip(fmt.Sprintf("Acceptance tests skipped unless env '%s' set", TestConfigAcceptanceTestKey.String()))
 	}
+}
+
+func (t *TestConfig) GetAddonIDorSkip(testing *testing.T) (val string) {
+	return t.GetOrSkip(testing, TestConfigAddonID)
 }
 
 func (t *TestConfig) GetAppIDorSkip(testing *testing.T) (val string) {

--- a/helper/test/helper.go
+++ b/helper/test/helper.go
@@ -3,9 +3,108 @@ package test
 import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"strings"
 )
 
 func GenerateRandomCIDR() string {
 	return fmt.Sprintf("%d.%d.%d.%d/32", acctest.RandIntRange(1, 10), acctest.RandIntRange(1, 10),
 		acctest.RandIntRange(1, 10), acctest.RandIntRange(1, 10))
+}
+
+const (
+	sentinelIndex = "*"
+)
+
+// The below few functions were copied from the AWS provider.
+
+// TestCheckTypeSetElemAttr is a resource.TestCheckFunc that accepts a resource
+// name, an attribute path, which should use the sentinel value '*' for indexing
+// into a TypeSet. The function verifies that an element matches the provided
+// value.
+//
+// Use this function over SDK provided TestCheckFunctions when validating a
+// TypeSet where its elements are a simple value
+func TestCheckTypeSetElemAttr(name, attr, value string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		is, err := instanceState(s, name)
+		if err != nil {
+			return err
+		}
+
+		err = testCheckTypeSetElem(is, attr, value)
+		if err != nil {
+			return fmt.Errorf("%q error: %s", name, err)
+		}
+
+		return nil
+	}
+}
+
+// TestCheckTypeSetElemAttrPair is a TestCheckFunc that verifies a pair of name/key
+// combinations are equal where the first uses the sentinel value to index into a
+// TypeSet.
+//
+// E.g., tfawsresource.TestCheckTypeSetElemAttrPair("aws_autoscaling_group.bar", "availability_zones.*", "data.aws_availability_zones.available", "names.0")
+func TestCheckTypeSetElemAttrPair(nameFirst, keyFirst, nameSecond, keySecond string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		isFirst, err := instanceState(s, nameFirst)
+		if err != nil {
+			return err
+		}
+
+		isSecond, err := instanceState(s, nameSecond)
+		if err != nil {
+			return err
+		}
+
+		vSecond, okSecond := isSecond.Attributes[keySecond]
+		if !okSecond {
+			return fmt.Errorf("%s: Attribute %q not set, cannot be checked against TypeSet", nameSecond, keySecond)
+		}
+
+		return testCheckTypeSetElem(isFirst, keyFirst, vSecond)
+	}
+}
+
+// instanceState returns the primary instance state for the given
+// resource name in the root module.
+func instanceState(s *terraform.State, name string) (*terraform.InstanceState, error) {
+	ms := s.RootModule()
+	rs, ok := ms.Resources[name]
+	if !ok {
+		return nil, fmt.Errorf("Not found: %s in %s", name, ms.Path)
+	}
+
+	is := rs.Primary
+	if is == nil {
+		return nil, fmt.Errorf("No primary instance: %s in %s", name, ms.Path)
+	}
+
+	return is, nil
+}
+
+func testCheckTypeSetElem(is *terraform.InstanceState, attr, value string) error {
+	attrParts := strings.Split(attr, ".")
+	if attrParts[len(attrParts)-1] != sentinelIndex {
+		return fmt.Errorf("%q does not end with the special value %q", attr, sentinelIndex)
+	}
+	for stateKey, stateValue := range is.Attributes {
+		if stateValue == value {
+			stateKeyParts := strings.Split(stateKey, ".")
+			if len(stateKeyParts) == len(attrParts) {
+				for i := range attrParts {
+					if attrParts[i] != stateKeyParts[i] && attrParts[i] != sentinelIndex {
+						break
+					}
+					if i == len(attrParts)-1 {
+						return nil
+					}
+				}
+			}
+		}
+	}
+
+	return fmt.Errorf("no TypeSet element %q, with value %q in state: %#v", attr, value, is.Attributes)
 }

--- a/herokux/config.go
+++ b/herokux/config.go
@@ -15,15 +15,19 @@ import (
 )
 
 const (
-	DefaultMTLSProvisionTimeout         = int64(10)
-	DefaultMTLSMTLSDeprovisionTimeout   = int64(10)
-	DefaultMTLSIPRuleCreateTimeout      = int64(10)
-	DefaultMTLSCertificateCreateTimeout = int64(10)
-	DefaultMTLSCertificateDeleteTimeout = int64(10)
-	DefaultKafkaCGCreateTimeout         = int64(10)
-	DefaultKafkaCGDeleteTimeout         = int64(10)
-	DefaultKafkaTopicCreateTimeout      = int64(10)
-	DefaultKafkaTopicUpdateTimeout      = int64(10)
+	DefaultMTLSProvisionTimeout                    = int64(10)
+	DefaultMTLSMTLSDeprovisionTimeout              = int64(10)
+	DefaultMTLSIPRuleCreateTimeout                 = int64(10)
+	DefaultMTLSCertificateCreateTimeout            = int64(10)
+	DefaultMTLSCertificateDeleteTimeout            = int64(10)
+	DefaultKafkaCGCreateTimeout                    = int64(10)
+	DefaultKafkaCGDeleteTimeout                    = int64(10)
+	DefaultKafkaTopicCreateTimeout                 = int64(10)
+	DefaultKafkaTopicUpdateTimeout                 = int64(10)
+	DefaultPrivatelinkCreateTimeoutt               = int64(15)
+	DefaultPrivatelinkDeleteTimeout                = int64(15)
+	DefaultPrivatelinkAllowedAccountsAddTimeout    = int64(10)
+	DefaultPrivatelinkAllowedAccountsRemoveTimeout = int64(10)
 )
 
 type Config struct {
@@ -34,28 +38,36 @@ type Config struct {
 	Headers     map[string]string
 
 	// Custom Timeouts
-	MTLSProvisionTimeout         int64
-	MTLSDeprovisionTimeout       int64
-	MTLSIPRuleCreateTimeout      int64
-	MTLSCertificateCreateTimeout int64
-	MTLSCertificateDeleteTimeout int64
-	KafkaCGCreateTimeout         int64
-	KafkaCGDeleteTimeout         int64
-	KafkaTopicCreateTimeout      int64
-	KafkaTopicUpdateTimeout      int64
+	MTLSProvisionTimeout                    int64
+	MTLSDeprovisionTimeout                  int64
+	MTLSIPRuleCreateTimeout                 int64
+	MTLSCertificateCreateTimeout            int64
+	MTLSCertificateDeleteTimeout            int64
+	KafkaCGCreateTimeout                    int64
+	KafkaCGDeleteTimeout                    int64
+	KafkaTopicCreateTimeout                 int64
+	KafkaTopicUpdateTimeout                 int64
+	PrivatelinkCreateTimeout                int64
+	PrivatelinkDeleteTimeout                int64
+	PrivatelinkAllowedAccountsAddTimeout    int64
+	PrivatelinkAllowedAccountsRemoveTimeout int64
 }
 
 func NewConfig() *Config {
 	c := &Config{
-		MTLSProvisionTimeout:         DefaultMTLSProvisionTimeout,
-		MTLSDeprovisionTimeout:       DefaultMTLSMTLSDeprovisionTimeout,
-		MTLSIPRuleCreateTimeout:      DefaultMTLSIPRuleCreateTimeout,
-		MTLSCertificateCreateTimeout: DefaultMTLSCertificateCreateTimeout,
-		MTLSCertificateDeleteTimeout: DefaultMTLSCertificateDeleteTimeout,
-		KafkaCGCreateTimeout:         DefaultKafkaCGCreateTimeout,
-		KafkaCGDeleteTimeout:         DefaultKafkaCGDeleteTimeout,
-		KafkaTopicCreateTimeout:      DefaultKafkaTopicCreateTimeout,
-		KafkaTopicUpdateTimeout:      DefaultKafkaTopicUpdateTimeout,
+		MTLSProvisionTimeout:                    DefaultMTLSProvisionTimeout,
+		MTLSDeprovisionTimeout:                  DefaultMTLSMTLSDeprovisionTimeout,
+		MTLSIPRuleCreateTimeout:                 DefaultMTLSIPRuleCreateTimeout,
+		MTLSCertificateCreateTimeout:            DefaultMTLSCertificateCreateTimeout,
+		MTLSCertificateDeleteTimeout:            DefaultMTLSCertificateDeleteTimeout,
+		KafkaCGCreateTimeout:                    DefaultKafkaCGCreateTimeout,
+		KafkaCGDeleteTimeout:                    DefaultKafkaCGDeleteTimeout,
+		KafkaTopicCreateTimeout:                 DefaultKafkaTopicCreateTimeout,
+		KafkaTopicUpdateTimeout:                 DefaultKafkaTopicUpdateTimeout,
+		PrivatelinkCreateTimeout:                DefaultPrivatelinkCreateTimeoutt,
+		PrivatelinkDeleteTimeout:                DefaultPrivatelinkDeleteTimeout,
+		PrivatelinkAllowedAccountsAddTimeout:    DefaultPrivatelinkAllowedAccountsAddTimeout,
+		PrivatelinkAllowedAccountsRemoveTimeout: DefaultPrivatelinkAllowedAccountsRemoveTimeout,
 	}
 	return c
 }
@@ -137,6 +149,22 @@ func (c *Config) applySchema(d *schema.ResourceData) (err error) {
 
 			if v, ok := delaysConfig["kafka_topic_update_timeout"].(int); ok {
 				c.KafkaTopicUpdateTimeout = int64(v)
+			}
+
+			if v, ok := delaysConfig["privatelink_create_timeout"].(int); ok {
+				c.PrivatelinkCreateTimeout = int64(v)
+			}
+
+			if v, ok := delaysConfig["privatelink_delete_timeout"].(int); ok {
+				c.PrivatelinkDeleteTimeout = int64(v)
+			}
+
+			if v, ok := delaysConfig["privatelink_allowed_acccounts_add_timeout"].(int); ok {
+				c.PrivatelinkAllowedAccountsAddTimeout = int64(v)
+			}
+
+			if v, ok := delaysConfig["privatelink_allowed_acccounts_remove_timeout"].(int); ok {
+				c.PrivatelinkAllowedAccountsRemoveTimeout = int64(v)
 			}
 		}
 	}

--- a/herokux/helpers.go
+++ b/herokux/helpers.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 )
 
-// getAppId extracts the app attribute generically from a HerokuX resource.
+// getAppId extracts the app ID attribute generically from a HerokuX resource.
 func getAppId(d *schema.ResourceData) string {
 	var appName string
 	if v, ok := d.GetOk("app_id"); ok {
@@ -17,6 +17,18 @@ func getAppId(d *schema.ResourceData) string {
 	}
 
 	return appName
+}
+
+// getAddonID extracts the addon ID attribute generically from a HerokuX resource.
+func getAddonID(d *schema.ResourceData) string {
+	var addonID string
+	if v, ok := d.GetOk("addon_id"); ok {
+		vs := v.(string)
+		log.Printf("[DEBUG] addon_id: %s", vs)
+		addonID = vs
+	}
+
+	return addonID
 }
 
 // getFormationName extracts the formation name attribute generically from a HerokuX resource.
@@ -63,4 +75,13 @@ func parseCompositeID(id string, numOfSplits int) ([]string, error) {
 			"Please check resource documentation for more information.", numOfSplits)
 	}
 	return parts, nil
+}
+
+func stringArrayContains(arr []string, str string) bool {
+	for _, a := range arr {
+		if a == str {
+			return true
+		}
+	}
+	return false
 }

--- a/herokux/import_herokux_privatelink_test.go
+++ b/herokux/import_herokux_privatelink_test.go
@@ -1,0 +1,30 @@
+package herokux
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"testing"
+)
+
+func TestAccHerokuxPrivatelink_importBasic(t *testing.T) {
+	addonID := testAccConfig.GetAddonIDorSkip(t)
+	allowedAccounts := "\"123456789123\", \"123456789124\""
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckHerokuxPrivatelink_basic(addonID, allowedAccounts),
+			},
+			{
+				ResourceName:      "herokux_privatelink.foobar",
+				ImportStateId:     fmt.Sprintf("%s", addonID),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/herokux/provider.go
+++ b/herokux/provider.go
@@ -104,6 +104,34 @@ func New() *schema.Provider {
 							Default:      10,
 							ValidateFunc: validation.IntAtLeast(3),
 						},
+
+						"privatelink_create_timeout": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Default:      15,
+							ValidateFunc: validation.IntAtLeast(5),
+						},
+
+						"privatelink_delete_timeout": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Default:      15,
+							ValidateFunc: validation.IntAtLeast(5),
+						},
+
+						"privatelink_allowed_acccounts_add_timeout": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Default:      10,
+							ValidateFunc: validation.IntAtLeast(2),
+						},
+
+						"privatelink_allowed_acccounts_remove_timeout": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Default:      10,
+							ValidateFunc: validation.IntAtLeast(2),
+						},
 					},
 				},
 			},
@@ -120,6 +148,7 @@ func New() *schema.Provider {
 			"herokux_postgres_mtls":             resourceHerokuxPostgresMTLS(),
 			"herokux_postgres_mtls_certificate": resourceHerokuxPostgresMTLSCertificate(),
 			"herokux_postgres_mtls_iprule":      resourceHerokuxPostgresMTLSIPRule(),
+			"herokux_privatelink":               resourceHerokuxPrivatelink(),
 		},
 
 		ConfigureContextFunc: providerConfigure,

--- a/herokux/resource_herokux_privatelink.go
+++ b/herokux/resource_herokux_privatelink.go
@@ -1,0 +1,327 @@
+package herokux
+
+import (
+	"context"
+	"fmt"
+	"github.com/davidji99/terraform-provider-herokux/api"
+	"github.com/davidji99/terraform-provider-herokux/api/data"
+	"github.com/davidji99/terraform-provider-herokux/api/postgres"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"log"
+	"time"
+)
+
+func resourceHerokuxPrivatelink() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceHerokuxPrivatelinkCreate,
+		ReadContext:   resourceHerokuxPrivatelinkRead,
+		UpdateContext: resourceHerokuxPrivatelinkUpdate,
+		DeleteContext: resourceHerokuxPrivatelinkDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceHerokuxPrivatelinkImport,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"addon_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.IsUUID,
+			},
+
+			"allowed_accounts": {
+				Type:     schema.TypeSet,
+				Required: true,
+				MinItems: 1,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"service_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+func resourceHerokuxPrivatelinkImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	d.SetId(d.Id())
+
+	readErr := resourceHerokuxPrivatelinkRead(ctx, d, meta)
+	if readErr.HasError() {
+		return nil, fmt.Errorf("unable to import %s", d.Id())
+	}
+
+	return []*schema.ResourceData{d}, nil
+}
+
+func resourceHerokuxPrivatelinkCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*Config)
+	client := config.API
+
+	addonID := getAddonID(d)
+	opts := &postgres.PrivatelinkRequest{}
+
+	if v, ok := d.GetOk("allowed_accounts"); ok {
+		aaRaw := v.(*schema.Set).List()
+		allowedAccounts := make([]string, 0)
+
+		for _, aa := range aaRaw {
+			allowedAccounts = append(allowedAccounts, aa.(string))
+		}
+
+		opts.AllowedAccounts = allowedAccounts
+		log.Printf("[DEBUG] allowed accounts are : %v", allowedAccounts)
+	}
+
+	log.Printf("[DEBUG] Creating Privatelink on addon %s", addonID)
+
+	pl, _, createErr := client.Postgres.CreatePrivatelink(addonID, opts)
+	if createErr != nil {
+		return diag.FromErr(createErr)
+	}
+
+	log.Printf("[DEBUG] Waiting for privatelink on %s to be provisioned", addonID)
+
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{data.PrivatelinkStatuses.PROVISIONING.ToString()},
+		Target:       []string{data.PrivatelinkStatuses.OPERATIONAL.ToString()},
+		Refresh:      PrivatelinkCreateStateRefreshFunc(client, addonID),
+		Timeout:      time.Duration(config.PrivatelinkCreateTimeout) * time.Minute,
+		PollInterval: 15 * time.Second,
+	}
+
+	if _, err := stateConf.WaitForStateContext(ctx); err != nil {
+		return diag.Errorf("error waiting for privatelink to be provisioned on %s: %s", addonID, err.Error())
+	}
+
+	d.SetId(pl.GetAddon().GetUUID())
+
+	return resourceHerokuxPrivatelinkRead(ctx, d, meta)
+}
+
+func resourceHerokuxPrivatelinkRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*Config).API
+
+	pl, _, readErr := client.Postgres.GetPrivatelink(d.Id())
+	if readErr != nil {
+		return diag.FromErr(readErr)
+	}
+
+	// Construct an array to store the allowed accounts account_id
+	accountIDs := make([]string, 0)
+	for _, aa := range pl.AllowedAccounts {
+		accountIDs = append(accountIDs, aa.GetAccountID())
+	}
+
+	d.Set("addon_id", pl.GetAddon().GetUUID())
+	d.Set("allowed_accounts", accountIDs)
+	d.Set("status", pl.Status.ToString())
+	d.Set("service_name", pl.GetServiceName())
+
+	return nil
+}
+
+func resourceHerokuxPrivatelinkUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*Config)
+	client := config.API
+
+	// The only updateable attribute for this resource is `allowed_accounts`. However, adding and removing `allowed_accounts`
+	// require different request types. Adding accounts requires a PUT but removing accounts requires a PATCH.
+	// Therefore, this resource needs to keep track of accounts being added and removed concurrently.
+	toAdd := make([]string, 0)
+	toRemove := make([]string, 0)
+
+	if d.HasChange("allowed_accounts") {
+		o, n := d.GetChange("allowed_accounts")
+		old := o.(*schema.Set).List()
+		oldF := formatSetListToStringList(old)
+		new := n.(*schema.Set).List()
+		newF := formatSetListToStringList(new)
+
+		// Determine the accounts to be removed
+		for _, id := range oldF {
+			if !stringArrayContains(newF, id) {
+				toRemove = append(toRemove, id)
+			}
+		}
+
+		// Determine the accounts to be added
+		for _, id := range newF {
+			if !stringArrayContains(oldF, id) {
+				toAdd = append(toAdd, id)
+			}
+		}
+	}
+
+	log.Printf("[DEBUG] List of account IDs to be removed %v", toRemove)
+	log.Printf("[DEBUG] List of account IDs to be added %v", toAdd)
+
+	if len(toRemove) > 0 {
+		log.Printf("[DEBUG] Removing the following account ids %v from %s", toRemove, d.Id())
+
+		_, _, removeErr := client.Postgres.RemovePrivatelinkAllowedAccounts(d.Id(),
+			&postgres.PrivatelinkRequest{AllowedAccounts: toRemove})
+
+		if removeErr != nil {
+			return diag.FromErr(removeErr)
+		}
+		log.Printf("[DEBUG] Removed the following account ids %v from %s", toRemove, d.Id())
+	}
+
+	if len(toAdd) > 0 {
+		log.Printf("[DEBUG] Adding the following account ids %v to %s", toAdd, d.Id())
+
+		_, _, addErr := client.Postgres.AddPrivatelinkAllowedAccounts(d.Id(),
+			&postgres.PrivatelinkRequest{AllowedAccounts: toAdd})
+
+		if addErr != nil {
+			return diag.FromErr(addErr)
+		}
+		log.Printf("[DEBUG] Added the following account ids %v to %s", toAdd, d.Id())
+
+		// The resource only needs to wait for newly added account ids to become `Active`.
+		log.Printf("[DEBUG] Waiting for added account IDS on %s to become active", d.Id())
+
+		stateConf := &resource.StateChangeConf{
+			Pending:      []string{data.PrivatelinkAllowedAccountStatuses.PROVISIONING.ToString()},
+			Target:       []string{data.PrivatelinkAllowedAccountStatuses.ACTIVE.ToString()},
+			Refresh:      PrivatelinkUpdateStateRefreshFunc(client, d.Id()),
+			Timeout:      time.Duration(config.PrivatelinkAllowedAccountsAddTimeout) * time.Minute,
+			PollInterval: 15 * time.Second,
+		}
+
+		if _, err := stateConf.WaitForStateContext(ctx); err != nil {
+			return diag.Errorf("error waiting for account ids to become active on %s: %s", d.Id(), err.Error())
+		}
+	}
+
+	return resourceHerokuxPrivatelinkRead(ctx, d, meta)
+}
+
+func formatSetListToStringList(raw []interface{}) []string {
+	formatted := make([]string, 0)
+	for _, v := range raw {
+		formatted = append(formatted, v.(string))
+	}
+
+	return formatted
+}
+
+func resourceHerokuxPrivatelinkDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*Config)
+	client := config.API
+
+	log.Printf("[DEBUG] Deleting privatelink on addon %s", d.Id())
+	_, _, deleteErr := client.Postgres.DeletePrivatelink(d.Id())
+	if deleteErr != nil {
+		return diag.FromErr(deleteErr)
+	}
+
+	log.Printf("[DEBUG] Waiting for privatelink on %s to be deprovisioned", d.Id())
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{data.PrivatelinkStatuses.DEPROVISIONING.ToString()},
+		Target:       []string{data.PrivatelinkStatuses.DEPROVISIONED.ToString()},
+		Refresh:      PrivatelinkDeleteStateRefreshFunc(client, d.Id()),
+		Timeout:      time.Duration(config.PrivatelinkDeleteTimeout) * time.Minute,
+		PollInterval: 15 * time.Second,
+	}
+
+	if _, err := stateConf.WaitForStateContext(ctx); err != nil {
+		return diag.Errorf("error waiting for privatelink to be deprovisioned on %s: %s", d.Id(), err.Error())
+	}
+
+	d.SetId("")
+
+	return nil
+}
+
+func PrivatelinkUpdateStateRefreshFunc(client *api.Client, addonID string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		pl, _, getErr := client.Postgres.GetPrivatelink(addonID)
+		if getErr != nil {
+			return nil, data.PrivatelinkAllowedAccountStatuses.UNKNOWN.ToString(), getErr
+		}
+
+		if !checkAccountsAreActive(pl) {
+			log.Printf("[DEBUG] Still waiting for privatelink allowed accounts on %s to become active", addonID)
+			return pl, data.PrivatelinkAllowedAccountStatuses.PROVISIONING.ToString(), nil
+		}
+
+		return pl, data.PrivatelinkAllowedAccountStatuses.ACTIVE.ToString(), nil
+	}
+}
+
+func PrivatelinkDeleteStateRefreshFunc(client *api.Client, addonID string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		pl, response, getErr := client.Postgres.GetPrivatelink(addonID)
+		if getErr != nil {
+			if response.StatusCode == 404 {
+				// 404 means the privatelink was deleted
+				return pl, data.PrivatelinkStatuses.DEPROVISIONED.ToString(), nil
+			}
+			// For all other statuses, return the error.
+			return nil, postgres.MTLSCertStatuses.UNKNOWN.ToString(), getErr
+		}
+
+		if pl.Status.ToString() == data.PrivatelinkStatuses.DEPROVISIONED.ToString() && response.StatusCode == 200 {
+			// When a privatelink is deleted, the GET request still returns a 200 with a privatelink status of 'deprovisioned'.
+			// This doesn't mean the privatelink was deleted/deprovisioned fully, so this resource will indicate a status
+			// of deprovisioning until the GET request returns a 404.
+			log.Printf("[DEBUG] Still waiting for privatelink on %s to be deleted", pl.GetAddon().GetUUID())
+			return pl, data.PrivatelinkStatuses.DEPROVISIONING.ToString(), nil
+		}
+
+		return nil, "", nil
+	}
+}
+
+func PrivatelinkCreateStateRefreshFunc(client *api.Client, addonID string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		// Check the status of both the privatelink and all allowed accounts.
+		pl, _, getErr := client.Postgres.GetPrivatelink(addonID)
+		if getErr != nil {
+			return nil, data.PrivatelinkStatuses.UNKNOWN.ToString(), getErr
+		}
+
+		if pl.Status.ToString() == data.PrivatelinkStatuses.PROVISIONING.ToString() {
+			log.Printf("[DEBUG] Still waiting for privatelink on %s to be provisioned", addonID)
+			return pl, pl.Status.ToString(), nil
+		}
+
+		if !checkAccountsAreActive(pl) {
+			log.Printf("[DEBUG] Still waiting for privatelink allowed accounts on %s to become active", addonID)
+			return pl, data.PrivatelinkAllowedAccountStatuses.PROVISIONING.ToString(), nil
+		}
+
+		return pl, data.PrivatelinkStatuses.OPERATIONAL.ToString(), nil
+	}
+}
+
+func checkAccountsAreActive(pl *postgres.Privatelink) bool {
+	// Loop through all the allowed accounts and gather their statuses.
+	// Store statuses in an array and check if the array has 'Provisioning' in it.
+	aaStatuses := make([]string, 0)
+
+	for _, aa := range pl.AllowedAccounts {
+		if aa.Status.ToString() == data.PrivatelinkAllowedAccountStatuses.PROVISIONING.ToString() {
+			aaStatuses = append(aaStatuses, aa.Status.ToString())
+		}
+	}
+
+	if stringArrayContains(aaStatuses, data.PrivatelinkAllowedAccountStatuses.PROVISIONING.ToString()) {
+		return false
+	}
+
+	return true
+}

--- a/herokux/resource_herokux_privatelink_test.go
+++ b/herokux/resource_herokux_privatelink_test.go
@@ -1,0 +1,64 @@
+package herokux
+
+import (
+	"fmt"
+	helper "github.com/davidji99/terraform-provider-herokux/helper/test"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"testing"
+)
+
+func TestAccHerokuxPrivatelink_Basic(t *testing.T) {
+	addonID := testAccConfig.GetAddonIDorSkip(t)
+	allowedAccounts := "\"123456789123\", \"123456789124\""
+	allowedAccountsUpdatedd := "\"123456789125\", \"123456789124\""
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckHerokuxPrivatelink_basic(addonID, allowedAccounts),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"herokux_privatelink.foobar", "addon_id", addonID),
+					resource.TestCheckResourceAttr(
+						"herokux_privatelink.foobar", "allowed_accounts.#", "2"),
+					helper.TestCheckTypeSetElemAttr("herokux_privatelink.foobar",
+						"allowed_accounts.*", "123456789123"),
+					helper.TestCheckTypeSetElemAttr("herokux_privatelink.foobar",
+						"allowed_accounts.*", "123456789124"),
+					resource.TestCheckResourceAttr(
+						"herokux_privatelink.foobar", "status", "Operational"),
+					resource.TestCheckResourceAttrSet(
+						"herokux_privatelink.foobar", "service_name"),
+				),
+			},
+			{
+				Config: testAccCheckHerokuxPrivatelink_basic(addonID, allowedAccountsUpdatedd),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"herokux_privatelink.foobar", "addon_id", addonID),
+					resource.TestCheckResourceAttr(
+						"herokux_privatelink.foobar", "allowed_accounts.#", "2"),
+					helper.TestCheckTypeSetElemAttr("herokux_privatelink.foobar",
+						"allowed_accounts.*", "123456789125"),
+					helper.TestCheckTypeSetElemAttr("herokux_privatelink.foobar",
+						"allowed_accounts.*", "123456789124"),
+					resource.TestCheckResourceAttr(
+						"herokux_privatelink.foobar", "status", "Operational"),
+					resource.TestCheckResourceAttrSet(
+						"herokux_privatelink.foobar", "service_name"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckHerokuxPrivatelink_basic(addonID, allowedAccounts string) string {
+	return fmt.Sprintf(`
+resource "herokux_privatelink" "foobar" {
+	addon_id = "%s"
+	allowed_accounts = [%s]
+}
+`, addonID, allowedAccounts)
+}

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -137,3 +137,12 @@ Only a single `timeouts` block may be specified and it supports the following ar
 
   * `kafka_topic_update_timeout` - (Optional) The number of minutes to wait for a Kafka topic to updated remotely.
   Defaults to 10 minutes. Minimum required is 3 minutes.
+
+  * `privatelink_create_timeout` - (Optional) The number of minutes to wait for a privatelink to be provisioned.
+  Defaults to 15 minutes. Minimum required is 5 minutes.
+
+  * `privatelink_delete_timeout` - (Optional) The number of minutes to wait for a privatelink to be deprovisioned.
+  Defaults to 15 minutes. Minimum required is 5 minutes.
+
+  * `privatelink_allowed_acccounts_add_timeout` - (Optional) The number of minutes to wait for allowed accounts
+  to become active for a privatelink. Defaults to 10 minutes. Minimum required is 2 minutes.

--- a/website/docs/r/privatelink.html.markdown
+++ b/website/docs/r/privatelink.html.markdown
@@ -1,0 +1,71 @@
+---
+layout: "herokux"
+page_title: "HerokuX: herokux_privatelink"
+sidebar_current: "docs-herokux-resource-privatelink"
+description: |-
+  Provides a resource to manage a privatelink for a Heroku Redis, Postgres, or Kafka addon.
+---
+
+# herokux\_privatelink
+
+This resource manages the privatelink configuration for a Heroku Redis, Postgres, or Kafka addon.
+For more information about each addon & privatelink, please refer to the following documentations:
+- [Connecting to Heroku Redis in a Private or Shield Space via PrivateLink](https://devcenter.heroku.com/articles/heroku-redis-via-privatelink)
+- [Connecting to a Private or Shield Heroku Postgres Database via PrivateLink](https://devcenter.heroku.com/articles/heroku-postgres-via-privatelink)
+- [Connecting to Apache Kafka on Heroku in a Private or Shield Space via PrivateLink](https://devcenter.heroku.com/articles/heroku-kafka-via-privatelink)
+
+-> **IMPORTANT!**
+To use this resource, the Amazon VPC Endpoint you create must be provisioned in a subnet
+that is in the same region as your Apache Kafka on Heroku add-on. New PrivateLink endpoints typically take
+between 5 and 10 minutes to become available.
+
+### Resource Timeouts
+During creation and deletion, this resource checks the status of the privatelink provisioning/deprovisioning
+as well as allowlisting AWS account IDs. All the aforementioned timeouts can be customized
+via the `timeouts.privatelink_create_timeout`, `timeouts.privatelink_delete_timeout`
+and `timeouts.privatelink_allowed_acccounts_add_timeout` in your `provider` block.
+
+For example:
+```hcl-terraform
+provider "herokux" {
+  timeouts {
+    privatelink_create_timeout = 20
+    privatelink_delete_timeout = 20
+    privatelink_allowed_acccounts_add_timeout = 20
+  }
+}
+```
+
+## Example Usage
+
+```hcl-terraform
+resource "herokux_privatelink" "foobar" {
+	addon_id = "SOME_ADDON_ID"
+	allowed_accounts = ["123456789123", "123456789124"]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `addon_id` - (Required) `<string>` The UUID of a Heroku postgres, redis or kafka addon.
+
+* `allowed_accounts` - (Required) `<list(string)>` Unordered list of AWS account IDs.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `status` - The status of privatelink configuration.
+
+* `service_name` - The privatelink endpoint service name.
+
+## Import
+
+An existing privatelink can be imported using the addon UUID.
+
+For example:
+```shell script
+$ terraform import herokux_privatelink.foobar <ADDON_UUID>
+```

--- a/website/herokux.erb
+++ b/website/herokux.erb
@@ -44,6 +44,10 @@
                 <li<%= sidebar_current("docs-herokux-resource-postgres-mtls-iprule") %>>
                   <a href="/docs/providers/herokux/r/postgres_mtls_iprule.html">herokux_postgres_mtls_iprule</a>
                 </li>
+
+                <li<%= sidebar_current("docs-herokux-resource-privatelink") %>>
+                  <a href="/docs/providers/herokux/r/privatelink.html">herokux_privatelink</a>
+                </li>
             </ul>
         </li>
       </ul>


### PR DESCRIPTION
- Resource can be used for Kafka, Postgres, and Redis.
- Initial `POST` and UI requires a valid AWS account ID but it can be removed afterwards.