### PR TITLE
(WIP) New resource herokux_postgres

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -18,8 +18,8 @@ const (
 	// DefaultPostgresAPIBaseURL is the default base URL for Postgres related APIs.
 	DefaultPostgresAPIBaseURL = "https://postgres-api.heroku.com"
 
-	// DefaultDataBaseURL is the default base URL for the Data Graph APIs.
-	DefaultDataBaseURL = "https://data-api.heroku.com"
+	// DefaultDataAPIBaseURL is the default base URL for the Data Graph APIs.
+	DefaultDataAPIBaseURL = "https://data-api.heroku.com"
 
 	// DefaultUserAgent is the user agent used when making API calls.
 	DefaultUserAgent = "herokux-go"
@@ -49,7 +49,7 @@ func New(opts ...config2.Option) (*Client, error) {
 		MetricsBaseURL:    DefaultMetricAPIBaseURL,
 		PostgresBaseURL:   DefaultPostgresAPIBaseURL,
 		KafkaBaseURL:      DefaultPostgresAPIBaseURL, // The Kafka API endpoints use the same base URL as postgres endpoints.
-		DataBaseURL:       DefaultDataBaseURL,
+		DataBaseURL:       DefaultDataAPIBaseURL,
 		UserAgent:         DefaultUserAgent,
 		APIToken:          "",
 		BasicAuth:         "",

--- a/api/postgres/database.go
+++ b/api/postgres/database.go
@@ -31,7 +31,14 @@ type DatabaseInfo struct {
 	ResolveDBName *bool         `json:"resolve_db_name,omitempty"`
 }
 
-func (p *Postgres) GetDatabase(dbID string) (*Database, *simpleresty.Response, error) {
+// DatabaseWaitStatus rerepresents the status of a database.
+type DatabaseWaitStatus struct {
+	Status    *string `json:"message,omitempty"`
+	IsWaiting *string `json:"waiting?,omitempty"`
+}
+
+// GetDB returns detailed information about a Heroku postgres database.
+func (p *Postgres) GetDB(dbID string) (*Database, *simpleresty.Response, error) {
 	var result *Database
 	urlStr := p.http.RequestURL("/client/v11/databases/%s", dbID)
 
@@ -41,7 +48,19 @@ func (p *Postgres) GetDatabase(dbID string) (*Database, *simpleresty.Response, e
 	return result, response, getErr
 }
 
-func (p *Postgres) UnfollowDatabase(dbID string) (*GenericResponse, *simpleresty.Response, error) {
+// GetDBWaitStatus returns the database's overall status and whether or not it is waiting.
+func (p *Postgres) GetDBWaitStatus(dbID string) (*DatabaseWaitStatus, *simpleresty.Response, error) {
+	var result *DatabaseWaitStatus
+	urlStr := p.http.RequestURL("/client/v11/databases/%s/wait_status", dbID)
+
+	// Execute the request
+	response, getErr := p.http.Get(urlStr, &result, nil)
+
+	return result, response, getErr
+}
+
+// UnfollowDatabase tells a follower DB to unfollow the leader DB.
+func (p *Postgres) UnfollowDB(dbID string) (*GenericResponse, *simpleresty.Response, error) {
 	var result *GenericResponse
 	urlStr := p.http.RequestURL("/client/v11/databases/%s/unfollow", dbID)
 
@@ -54,10 +73,6 @@ func (p *Postgres) UnfollowDatabase(dbID string) (*GenericResponse, *simpleresty
 	response, err := p.http.Put(urlStr, &result, &body)
 
 	return result, response, err
-}
-
-func (p *Postgres) PromoteDatabase() {
-
 }
 
 func (d *Database) FindInfoByName(name string) *DatabaseInfo {

--- a/api/postgres/database.go
+++ b/api/postgres/database.go
@@ -1,0 +1,52 @@
+package postgres
+
+import "github.com/davidji99/simpleresty"
+
+// Database represents a Heroku postgres database
+type Database struct {
+	Following           *string         `json:"following,omitempty"`
+	HotStandby          *bool           `json:"hot_standby,omitempty"`
+	AddonID             *string         `json:"addon_id,omitempty"`
+	Name                *string         `json:"name,omitempty"`
+	HerokuResourceID    *string         `json:"heroku_resource_id,omitempty"`
+	MetaasSource        *string         `json:"metaas_source,omitempty"`
+	PostgresVersion     *string         `json:"postgres_version,omitempty"`
+	AvailableForIngress *bool           `json:"available_for_ingress,omitempty"`
+	ResourceURL         *string         `json:"resource_url,omitempty"`
+	Waiting             *bool           `json:"waiting?,omitempty"`
+	Leader              *DatabaseLeader `json:"leader,omitempty"`
+	Info                []*DatabaseInfo `json:"info,omitempty"`
+}
+
+// DatabaseLeader represents a database's leader
+type DatabaseLeader struct {
+	AddonID *string `json:"addon_id,omitempty"`
+	Name    *string `json:"name,omitempty"`
+}
+
+// DatabaseInfo represents a database's information.
+type DatabaseInfo struct {
+	Name          *string       `json:"name,omitempty"`
+	Values        []interface{} `json:"values,omitempty"` // most of the values are strings
+	ResolveDBName *bool         `json:"resolve_db_name,omitempty"`
+}
+
+func (p *Postgres) GetDatabase(dbID string) (*Database, *simpleresty.Response, error) {
+	var result *Database
+	urlStr := p.http.RequestURL("/client/v11/databases/%s", dbID)
+
+	// Execute the request
+	response, createErr := p.http.Post(urlStr, &result, nil)
+
+	return result, response, createErr
+}
+
+func (d *Database) FindInfoByName(name string) *DatabaseInfo {
+	for _, i := range d.Info {
+		if i.GetName() == name {
+			return i
+		}
+	}
+
+	return nil
+}

--- a/api/postgres/database.go
+++ b/api/postgres/database.go
@@ -36,7 +36,7 @@ func (p *Postgres) GetDatabase(dbID string) (*Database, *simpleresty.Response, e
 	urlStr := p.http.RequestURL("/client/v11/databases/%s", dbID)
 
 	// Execute the request
-	response, createErr := p.http.Post(urlStr, &result, nil)
+	response, createErr := p.http.Get(urlStr, &result, nil)
 
 	return result, response, createErr
 }

--- a/api/postgres/database.go
+++ b/api/postgres/database.go
@@ -36,9 +36,28 @@ func (p *Postgres) GetDatabase(dbID string) (*Database, *simpleresty.Response, e
 	urlStr := p.http.RequestURL("/client/v11/databases/%s", dbID)
 
 	// Execute the request
-	response, createErr := p.http.Get(urlStr, &result, nil)
+	response, getErr := p.http.Get(urlStr, &result, nil)
 
-	return result, response, createErr
+	return result, response, getErr
+}
+
+func (p *Postgres) UnfollowDatabase(dbID string) (*GenericResponse, *simpleresty.Response, error) {
+	var result *GenericResponse
+	urlStr := p.http.RequestURL("/client/v11/databases/%s/unfollow", dbID)
+
+	// Construct request body
+	body := struct {
+		Host string `json:"host"`
+	}{Host: ""}
+
+	// Execute the request
+	response, err := p.http.Put(urlStr, &result, &body)
+
+	return result, response, err
+}
+
+func (p *Postgres) PromoteDatabase() {
+
 }
 
 func (d *Database) FindInfoByName(name string) *DatabaseInfo {

--- a/api/postgres/postgres-accessors.go
+++ b/api/postgres/postgres-accessors.go
@@ -9,6 +9,148 @@ import (
 	"time"
 )
 
+// GetAddonID returns the AddonID field if it's non-nil, zero value otherwise.
+func (d *Database) GetAddonID() string {
+	if d == nil || d.AddonID == nil {
+		return ""
+	}
+	return *d.AddonID
+}
+
+// GetAvailableForIngress returns the AvailableForIngress field if it's non-nil, zero value otherwise.
+func (d *Database) GetAvailableForIngress() bool {
+	if d == nil || d.AvailableForIngress == nil {
+		return false
+	}
+	return *d.AvailableForIngress
+}
+
+// GetFollowing returns the Following field if it's non-nil, zero value otherwise.
+func (d *Database) GetFollowing() string {
+	if d == nil || d.Following == nil {
+		return ""
+	}
+	return *d.Following
+}
+
+// GetHerokuResourceID returns the HerokuResourceID field if it's non-nil, zero value otherwise.
+func (d *Database) GetHerokuResourceID() string {
+	if d == nil || d.HerokuResourceID == nil {
+		return ""
+	}
+	return *d.HerokuResourceID
+}
+
+// GetHotStandby returns the HotStandby field if it's non-nil, zero value otherwise.
+func (d *Database) GetHotStandby() bool {
+	if d == nil || d.HotStandby == nil {
+		return false
+	}
+	return *d.HotStandby
+}
+
+// HasInfo checks if Database has any Info.
+func (d *Database) HasInfo() bool {
+	if d == nil || d.Info == nil {
+		return false
+	}
+	if len(d.Info) == 0 {
+		return false
+	}
+	return true
+}
+
+// GetLeader returns the Leader field.
+func (d *Database) GetLeader() *DatabaseLeader {
+	if d == nil {
+		return nil
+	}
+	return d.Leader
+}
+
+// GetMetaasSource returns the MetaasSource field if it's non-nil, zero value otherwise.
+func (d *Database) GetMetaasSource() string {
+	if d == nil || d.MetaasSource == nil {
+		return ""
+	}
+	return *d.MetaasSource
+}
+
+// GetName returns the Name field if it's non-nil, zero value otherwise.
+func (d *Database) GetName() string {
+	if d == nil || d.Name == nil {
+		return ""
+	}
+	return *d.Name
+}
+
+// GetPostgresVersion returns the PostgresVersion field if it's non-nil, zero value otherwise.
+func (d *Database) GetPostgresVersion() string {
+	if d == nil || d.PostgresVersion == nil {
+		return ""
+	}
+	return *d.PostgresVersion
+}
+
+// GetResourceURL returns the ResourceURL field if it's non-nil, zero value otherwise.
+func (d *Database) GetResourceURL() string {
+	if d == nil || d.ResourceURL == nil {
+		return ""
+	}
+	return *d.ResourceURL
+}
+
+// GetWaiting returns the Waiting field if it's non-nil, zero value otherwise.
+func (d *Database) GetWaiting() bool {
+	if d == nil || d.Waiting == nil {
+		return false
+	}
+	return *d.Waiting
+}
+
+// GetName returns the Name field if it's non-nil, zero value otherwise.
+func (d *DatabaseInfo) GetName() string {
+	if d == nil || d.Name == nil {
+		return ""
+	}
+	return *d.Name
+}
+
+// GetResolveDBName returns the ResolveDBName field if it's non-nil, zero value otherwise.
+func (d *DatabaseInfo) GetResolveDBName() bool {
+	if d == nil || d.ResolveDBName == nil {
+		return false
+	}
+	return *d.ResolveDBName
+}
+
+// HasValues checks if DatabaseInfo has any Values.
+func (d *DatabaseInfo) HasValues() bool {
+	if d == nil || d.Values == nil {
+		return false
+	}
+	if len(d.Values) == 0 {
+		return false
+	}
+	return true
+}
+
+// GetAddonID returns the AddonID field if it's non-nil, zero value otherwise.
+func (d *DatabaseLeader) GetAddonID() string {
+	if d == nil || d.AddonID == nil {
+		return ""
+	}
+	return *d.AddonID
+}
+
+// GetName returns the Name field if it's non-nil, zero value otherwise.
+func (d *DatabaseLeader) GetName() string {
+	if d == nil || d.Name == nil {
+		return ""
+	}
+	return *d.Name
+}
+
 // HasActiveIPRules checks if MTLS has any ActiveIPRules.
 func (m *MTLS) HasActiveIPRules() bool {
 	if m == nil || m.ActiveIPRules == nil {

--- a/api/postgres/postgres-accessors.go
+++ b/api/postgres/postgres-accessors.go
@@ -151,6 +151,38 @@ func (d *DatabaseLeader) GetName() string {
 	return *d.Name
 }
 
+// GetIsWaiting returns the IsWaiting field if it's non-nil, zero value otherwise.
+func (d *DatabaseWaitStatus) GetIsWaiting() string {
+	if d == nil || d.IsWaiting == nil {
+		return ""
+	}
+	return *d.IsWaiting
+}
+
+// GetStatus returns the Status field if it's non-nil, zero value otherwise.
+func (d *DatabaseWaitStatus) GetStatus() string {
+	if d == nil || d.Status == nil {
+		return ""
+	}
+	return *d.Status
+}
+
+// GetID returns the ID field if it's non-nil, zero value otherwise.
+func (g *GenericResponse) GetID() string {
+	if g == nil || g.ID == nil {
+		return ""
+	}
+	return *g.ID
+}
+
+// GetMessage returns the Message field if it's non-nil, zero value otherwise.
+func (g *GenericResponse) GetMessage() string {
+	if g == nil || g.Message == nil {
+		return ""
+	}
+	return *g.Message
+}
+
 // HasActiveIPRules checks if MTLS has any ActiveIPRules.
 func (m *MTLS) HasActiveIPRules() bool {
 	if m == nil || m.ActiveIPRules == nil {

--- a/api/postgres/postgres.go
+++ b/api/postgres/postgres.go
@@ -13,6 +13,12 @@ type Postgres struct {
 	config *config2.Config
 }
 
+// GenericResponse represents a generic response from the Postgres API.
+type GenericResponse struct {
+	ID      *string `json:"id,omitempty"`
+	Message *string `json:"message,omitempty"`
+}
+
 // New constructs a client to interface with the Heroku Postgres APIs.
 func New(config *config2.Config) *Postgres {
 	p := &Postgres{http: simpleresty.NewWithBaseURL(config.PostgresBaseURL), config: config}

--- a/api/postgres/types.go
+++ b/api/postgres/types.go
@@ -66,3 +66,34 @@ var MTLSCertStatuses = struct {
 func (s MTLSCertStatus) ToString() string {
 	return string(s)
 }
+
+// DatabaseInfoName represents a database info name.
+type DatabaseInfoName string
+
+// DatabaseInfoNames represents database infor names.
+var DatabaseInfoNames = struct {
+	PLAN       DatabaseInfoName
+	STATUS     DatabaseInfoName
+	HASTATUS   DatabaseInfoName
+	DATASIZE   DatabaseInfoName
+	PGVERSION  DatabaseInfoName
+	FORKFOLLOW DatabaseInfoName
+	REGION     DatabaseInfoName
+	MUTUALTLS  DatabaseInfoName
+	FOLLOWERS  DatabaseInfoName
+}{
+	PLAN:       "Plan",
+	STATUS:     "Status",
+	HASTATUS:   "HA Status",
+	DATASIZE:   "Data Size",
+	PGVERSION:  "PG Version",
+	FORKFOLLOW: "Fork/Follow",
+	REGION:     "Region",
+	MUTUALTLS:  "Mutual TLS",
+	FOLLOWERS:  "Followers",
+}
+
+// ToString is a helper method to return the string of a DatabaseInfoName.
+func (s DatabaseInfoName) ToString() string {
+	return string(s)
+}

--- a/herokux/provider.go
+++ b/herokux/provider.go
@@ -6,6 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	heroku "github.com/heroku/heroku-go/v5"
 	"log"
 )
 
@@ -15,19 +16,33 @@ func New() *schema.Provider {
 			"api_key": {
 				Type:        schema.TypeString,
 				Optional:    true,
+				// Same environment variable to keep things consistent with the Heroku provider.
 				DefaultFunc: schema.EnvDefaultFunc("HEROKU_API_KEY", nil),
 			},
 
 			"metrics_api_url": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("HEROKU_METRICS_API_URL", api.DefaultMetricAPIBaseURL),
+				DefaultFunc: schema.EnvDefaultFunc("HEROKUX_METRICS_API_URL", api.DefaultMetricAPIBaseURL),
 			},
 
 			"postgres_api_url": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("HEROKU_POSTGRES_API_URL", api.DefaultPostgresAPIBaseURL),
+				DefaultFunc: schema.EnvDefaultFunc("HEROKUX_POSTGRES_API_URL", api.DefaultPostgresAPIBaseURL),
+			},
+
+			"data_api_url": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("HEROKUX_DATA_API_URL", api.DefaultDataAPIBaseURL),
+			},
+
+			"platform_api_url": {
+				Type:     schema.TypeString,
+				Optional: true,
+				// Same environment variable to keep things consistent with the Heroku provider.
+				DefaultFunc: schema.EnvDefaultFunc("HEROKU_API_URL", heroku.DefaultURL),
 			},
 
 			"headers": {

--- a/herokux/provider.go
+++ b/herokux/provider.go
@@ -160,11 +160,12 @@ func New() *schema.Provider {
 			"herokux_formation_autoscaling":     resourceHerokuxFormationAutoscaling(),
 			"herokux_kafka_consumer_group":      resourceHerokuxKafkaConsumerGroup(),
 			"herokux_kafka_topic":               resourceHerokuxKafkaTopic(),
-			"herokux_postgres":                  resourceHerokuxPostgres(),
 			"herokux_postgres_mtls":             resourceHerokuxPostgresMTLS(),
 			"herokux_postgres_mtls_certificate": resourceHerokuxPostgresMTLSCertificate(),
 			"herokux_postgres_mtls_iprule":      resourceHerokuxPostgresMTLSIPRule(),
 			"herokux_privatelink":               resourceHerokuxPrivatelink(),
+
+			//"herokux_postgres":                  resourceHerokuxPostgres(),
 		},
 
 		ConfigureContextFunc: providerConfigure,

--- a/herokux/provider.go
+++ b/herokux/provider.go
@@ -14,8 +14,8 @@ func New() *schema.Provider {
 	return &schema.Provider{
 		Schema: map[string]*schema.Schema{
 			"api_key": {
-				Type:        schema.TypeString,
-				Optional:    true,
+				Type:     schema.TypeString,
+				Optional: true,
 				// Same environment variable to keep things consistent with the Heroku provider.
 				DefaultFunc: schema.EnvDefaultFunc("HEROKU_API_KEY", nil),
 			},
@@ -160,6 +160,7 @@ func New() *schema.Provider {
 			"herokux_formation_autoscaling":     resourceHerokuxFormationAutoscaling(),
 			"herokux_kafka_consumer_group":      resourceHerokuxKafkaConsumerGroup(),
 			"herokux_kafka_topic":               resourceHerokuxKafkaTopic(),
+			"herokux_postgres":                  resourceHerokuxPostgres(),
 			"herokux_postgres_mtls":             resourceHerokuxPostgresMTLS(),
 			"herokux_postgres_mtls_certificate": resourceHerokuxPostgresMTLSCertificate(),
 			"herokux_postgres_mtls_iprule":      resourceHerokuxPostgresMTLSIPRule(),

--- a/herokux/resource_herokux_postgres.go
+++ b/herokux/resource_herokux_postgres.go
@@ -1,0 +1,1 @@
+package herokux

--- a/herokux/resource_herokux_postgres.go
+++ b/herokux/resource_herokux_postgres.go
@@ -426,7 +426,7 @@ func AddOnStateRefreshFunc(platformAPI *heroku.Service, addOnID string) resource
 // FollowStateRefreshFunc checks if a DB is ready to be followed
 func FollowStateRefreshFunc(api *api.Client, dbID string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		db, _, getErr := api.Postgres.GetDatabase(dbID)
+		db, _, getErr := api.Postgres.GetDB(dbID)
 		if getErr != nil {
 			return nil, "", getErr
 		}

--- a/herokux/resource_herokux_postgres.go
+++ b/herokux/resource_herokux_postgres.go
@@ -1,1 +1,311 @@
 package herokux
+
+import (
+	"context"
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	heroku "github.com/heroku/heroku-go/v5"
+	"log"
+	"regexp"
+	"time"
+)
+
+const (
+	Leader   = "leader"
+	follower = "follower"
+)
+
+func resourceHerokuxPostgres() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceHerokuxPostgresCreate,
+		ReadContext:   resourceHerokuxPostgresRead,
+		UpdateContext: resourceHerokuxPostgresUpdate,
+		DeleteContext: resourceHerokuxPostgresDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceHerokuxPostgresImport,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"database": {
+				Type:     schema.TypeSet,
+				Required: true,
+				MinItems: 1,
+				MaxItems: 2, // Increase this later on to support multiple followers for a leader.
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"position": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice([]string{Leader, follower}, false),
+						},
+
+						"app_id": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ForceNew:     true,
+							ValidateFunc: validation.IsUUID,
+						},
+
+						"plan": {
+							// Value required is the plan itself sans the 'heroku-postgresql:' part.
+							Type:     schema.TypeString,
+							Required: true,
+						},
+
+						//"name": {
+						//	Type:         schema.TypeString,
+						//	Optional:     true,
+						//	Computed:     true,
+						//	ValidateFunc: validateCustomAddonName,
+						//},
+
+						//"config": {
+						//	Type:     schema.TypeMap,
+						//	Optional: true,
+						//	ForceNew: true,
+						//},
+
+						"config_var": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
+						"addon_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
+						"addon_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
+						"addon_attachment_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+
+			"database_leader_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"database_follower_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceHerokuxPostgresImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	return nil, nil
+}
+
+func resourceHerokuxPostgresCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*Config)
+	platformAPI := config.PlatformAPI
+
+	// Define variables to create new leader & follower datbaases
+	leaderOpts := heroku.AddOnCreateOpts{}
+	var followerOpts heroku.AddOnCreateOpts
+
+	// Define variables to store addon app IDs.
+	var leaderAppID string
+	var followerAppID string
+
+	createFollower := false
+
+	// Validate to make sure there's one database block set to `Leader`.
+	if v, ok := d.GetOk("database"); ok {
+		vl := v.(*schema.Set).List()
+
+		// Collect all positions
+		dbPositions := make([]string, 0)
+		for _, db := range vl {
+			dbInfo := db.(map[string]interface{})
+			if pRaw, ok := dbInfo["position"]; ok {
+				dbPositions = append(dbPositions, pRaw.(string))
+			}
+		}
+
+		log.Printf("[DEBUG] List of database positions : %v", dbPositions)
+
+		// Check if Leader position is present. If not, error out.
+		if !stringArrayContains(dbPositions, Leader) {
+			return diag.Errorf("did not specify a database with position of '%s' even if you're only creating one database", Leader)
+		}
+
+		// Collect information regarding the Leader database.
+		// There will always be a Leader database so no need to do a nil check.
+		leaderInfo := getDatabaseInfo(vl, Leader)
+		if appIdRaw, ok := leaderInfo["app_id"]; ok {
+			leaderAppID = appIdRaw.(string)
+			log.Printf("[DEBUG] database leader app_id : %v", leaderAppID)
+			leaderOpts.Confirm = &leaderAppID
+		}
+
+		if planRaw, ok := leaderInfo["plan"]; ok {
+			plan := planRaw.(string)
+			log.Printf("[DEBUG] database leader plan : %v", plan)
+			leaderOpts.Plan = fmt.Sprintf("heroku-postgresql:%s", plan)
+		}
+
+		log.Printf("[DEBUG] Database leader create opts : %v", leaderOpts)
+
+		// Collect information regarding the follower database. For now, there will only be one follower database.
+		followerInfo := getDatabaseInfo(vl, follower)
+		createFollower = followerInfo != nil
+		if createFollower {
+			if appIdRaw, ok := followerInfo["app_id"]; ok {
+				followerAppID = appIdRaw.(string)
+				log.Printf("[DEBUG] database follower app_id : %v", followerAppID)
+				followerOpts.Confirm = &followerAppID
+			}
+
+			if planRaw, ok := followerInfo["plan"]; ok {
+				plan := planRaw.(string)
+				log.Printf("[DEBUG] database follower plan : %v", plan)
+				followerOpts.Plan = fmt.Sprintf("heroku-postgresql:%s", plan)
+			}
+
+			// Set the followerOpts.Config `follow` attribute to follow the leader database
+			followerOpts.Config = map[string]string{
+				"follow": fmt.Sprintf("%s::DATABASE_URL", leaderAppID),
+			}
+		} else {
+			log.Printf("[DEBUG] No database follower defined. Skipping...")
+		}
+
+		log.Printf("[DEBUG] Database follower create opts : %v", followerOpts)
+	}
+
+	// Now proceed to create the database leader.
+	log.Printf("[DEBUG] Creating database leader...")
+	leaderDB, leaderCreateErr := platformAPI.AddOnCreate(context.TODO(), leaderAppID, leaderOpts)
+	if leaderCreateErr != nil {
+		return diag.FromErr(leaderCreateErr)
+	}
+
+	log.Printf("[INFO] Database leader ID: %s", leaderDB.ID)
+
+	// Wait for the database leader to be provisioned
+	log.Printf("[INFO] Waiting for database leader ID (%s) to be provisioned", leaderDB.ID)
+	leaderStateConf := &resource.StateChangeConf{
+		Pending: []string{"provisioning"},
+		Target:  []string{"provisioned"},
+		Refresh: AddOnStateRefreshFunc(platformAPI, leaderDB.ID),
+		Timeout: 20 * time.Minute,
+	}
+
+	if _, err := leaderStateConf.WaitForStateContext(ctx); err != nil {
+		return diag.Errorf("Error waiting for database leader (%s) to be provisioned: %s", leaderDB.ID, err)
+	}
+
+	// Now proceed to create follower database if applicable.
+	followerDBAppID := ""
+	if createFollower {
+		log.Printf("[DEBUG] Creating database follower...")
+		followerDB, followerCreateErr := platformAPI.AddOnCreate(context.TODO(), followerAppID, followerOpts)
+		if followerCreateErr != nil {
+			return diag.FromErr(followerCreateErr)
+		}
+
+		log.Printf("[INFO] Database follower ID: %s", followerDB.ID)
+
+		// Wait for the database leader to be provisioned
+		log.Printf("[INFO] Waiting for database follower ID (%s) to be provisioned", followerDB.ID)
+		followerStateConf := &resource.StateChangeConf{
+			Pending: []string{"provisioning"},
+			Target:  []string{"provisioned"},
+			Refresh: AddOnStateRefreshFunc(platformAPI, followerDB.ID),
+			Timeout: 20 * time.Minute,
+		}
+
+		if _, err := followerStateConf.WaitForStateContext(ctx); err != nil {
+			return diag.Errorf("Error waiting for database follower (%s) to be provisioned: %s", followerDB.ID, err)
+		}
+
+		followerDBAppID = followerDB.App.ID
+	}
+
+	// If a leader & follower are created, set the resource ID to be a composite of the databases app IDs.
+	// Otherwise, set the resource ID to the database leader app ID.
+	if createFollower {
+		d.SetId(fmt.Sprintf("%s:%s", leaderDB.App.ID, followerDBAppID))
+	} else {
+		d.SetId(fmt.Sprintf("%s", leaderDB.App.ID))
+	}
+
+	return resourceHerokuxPostgresRead(ctx, d, meta)
+}
+
+func getDatabaseInfo(dbList []interface{}, position string) map[string]interface{} {
+	for _, db := range dbList {
+		dbInfo := db.(map[string]interface{})
+		if pRaw, pOK := dbInfo["position"]; pOK {
+			if pRaw.(string) == position {
+				return dbInfo
+			}
+		}
+	}
+	return nil
+}
+
+func resourceHerokuxPostgresRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceHerokuxPostgresUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceHerokuxPostgresDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return nil
+}
+
+func validateCustomAddonName(v interface{}, k string) (ws []string, errors []error) {
+	// Check length
+	v1 := validation.StringLenBetween(1, 256)
+	_, errs1 := v1(v, k)
+	for _, err := range errs1 {
+		errors = append(errors, err)
+	}
+
+	// Check validity
+	valRegex := regexp.MustCompile(`^[a-zA-Z][A-Za-z0-9_-]+$`)
+	v2 := validation.StringMatch(valRegex, "Invalid custom addon name: must start with a letter and can only contain lowercase letters, numbers, and dashes")
+	_, errs2 := v2(v, k)
+	for _, err := range errs2 {
+		errors = append(errors, err)
+	}
+
+	return ws, errors
+}
+
+// AddOnStateRefreshFunc returns a resource.StateRefreshFunc that is used to
+// watch an AddOn.
+func AddOnStateRefreshFunc(platformAPI *heroku.Service, addOnID string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		addon, getErr := platformAPI.AddOnInfo(context.TODO(), addOnID)
+		if getErr != nil {
+			return nil, "", getErr
+		}
+
+		// The type conversion here can be dropped when the vendored version of
+		// heroku-go is updated.
+		return addon, addon.State, nil
+	}
+}

--- a/herokux/resource_herokux_postgres.go
+++ b/herokux/resource_herokux_postgres.go
@@ -178,7 +178,7 @@ func resourceHerokuxPostgresCreate(ctx context.Context, d *schema.ResourceData, 
 		if planRaw, ok := leaderInfo["plan"]; ok {
 			plan := planRaw.(string)
 			log.Printf("[DEBUG] database leader plan : %v", plan)
-			leaderOpts.Plan = fmt.Sprintf("heroku-postgresql:%s", plan)
+			leaderOpts.Plan = plan
 		}
 
 		log.Printf("[DEBUG] Database leader create opts : %v", leaderOpts)
@@ -288,17 +288,16 @@ func resourceHerokuxPostgresCreate(ctx context.Context, d *schema.ResourceData, 
 
 func resourceHerokuxPostgresRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*Config)
-	api := config.API
+	//api := config.API
 	platformAPI := config.PlatformAPI
 
-	var leaderAppID, leaderDatabaseID, followerAppID, followerDatabaseID string
+	var leaderDatabaseID, followerDatabaseID string
 	var dbs []map[string]interface{}
 
 	// Parse resource ID
 	resourceIDList := strings.Split(d.Id(), ":")
 
 	// Set leader database info in state
-	leaderAppID = strings.Split(resourceIDList[0], "|")[0]
 	leaderDatabaseID = strings.Split(resourceIDList[0], "|")[1]
 	leaderDB, getLErr := platformAPI.AddOnInfo(context.TODO(), leaderDatabaseID)
 	if getLErr != nil {
@@ -306,17 +305,16 @@ func resourceHerokuxPostgresRead(ctx context.Context, d *schema.ResourceData, me
 	}
 
 	leader := map[string]interface{}{
-		"position":   Leader,
-		"app_id":     leaderDB.App.ID,
-		"plan":       leaderDB.Plan.Name,
-		"config_var": leaderDB.ConfigVars,
-		"id":         leaderDB.ID,
-		"name":       leaderDB.Name,
+		"position":    Leader,
+		"app_id":      leaderDB.App.ID,
+		"plan":        leaderDB.Plan.Name,
+		"config_vars": leaderDB.ConfigVars,
+		"id":          leaderDB.ID,
+		"name":        leaderDB.Name,
 	}
 	dbs = append(dbs, leader)
 
 	if len(resourceIDList) >= 2 {
-		followerAppID = strings.Split(resourceIDList[1], "|")[0]
 		followerDatabaseID = strings.Split(resourceIDList[1], "|")[1]
 		followerDB, getFErr := platformAPI.AddOnInfo(context.TODO(), followerDatabaseID)
 		if getFErr != nil {
@@ -324,12 +322,12 @@ func resourceHerokuxPostgresRead(ctx context.Context, d *schema.ResourceData, me
 		}
 
 		follower := map[string]interface{}{
-			"position":   Leader,
-			"app_id":     followerDB.App.ID,
-			"plan":       followerDB.Plan.Name,
-			"config_var": followerDB.ConfigVars,
-			"id":         followerDB.ID,
-			"name":       followerDB.Name,
+			"position":    follower,
+			"app_id":      followerDB.App.ID,
+			"plan":        followerDB.Plan.Name,
+			"config_vars": followerDB.ConfigVars,
+			"id":          followerDB.ID,
+			"name":        followerDB.Name,
 		}
 		dbs = append(dbs, follower)
 	}

--- a/herokux/resource_herokux_postgres.go
+++ b/herokux/resource_herokux_postgres.go
@@ -116,6 +116,7 @@ func resourceHerokuxPostgres() *schema.Resource {
 				Computed: true,
 			},
 		},
+		//CustomizeDiff: nil, TODO: add the validation ensuring a leader position exists
 	}
 }
 
@@ -166,7 +167,7 @@ func resourceHerokuxPostgresCreate(ctx context.Context, d *schema.ResourceData, 
 			return diag.Errorf("did not specify a database with position of '%s' even if you're only creating one database", Leader)
 		}
 
-		// Collect information regarding the Leader database.
+		// Collect information regarding the leader from the `database` attribute.
 		// There will always be a Leader database so no need to do a nil check.
 		leaderInfo := getDatabaseInfo(vl, Leader)
 		if appIdRaw, ok := leaderInfo["app_id"]; ok {

--- a/herokux/resource_herokux_postgres_test.go
+++ b/herokux/resource_herokux_postgres_test.go
@@ -42,6 +42,12 @@ func TestAccHerokuxPostgres_LeaderAndFollower(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
 						"herokux_postgres.foobar", "description", "High Availablility for Foobar"),
+					resource.TestCheckResourceAttrSet(
+						"herokux_postgres.foobar", "database_leader_id"),
+					resource.TestCheckResourceAttrSet(
+						"herokux_postgres.foobar", "database_follower_id"),
+					resource.TestCheckResourceAttr(
+						"herokux_postgres.foobar", "database_count", "2"),
 					resource.TestCheckResourceAttr(
 						"herokux_postgres.foobar", "database.#", "2"),
 					//helper.TestCheckTypeSetElemAttr("herokux_postgres.foobar",
@@ -55,8 +61,6 @@ func TestAccHerokuxPostgres_LeaderAndFollower(t *testing.T) {
 func testAccCheckHerokuxPostgres_OnlyLeader(appID, plan string) string {
 	return fmt.Sprintf(`
 resource "herokux_postgres" "foobar" {
-	description = "High Availablility for Foobar"
-
 	database {
 		position = "leader"
 		app_id = "%s"
@@ -69,8 +73,6 @@ resource "herokux_postgres" "foobar" {
 func testAccCheckHerokuxPostgres_LeaderAndFollower(appID, plan string) string {
 	return fmt.Sprintf(`
 resource "herokux_postgres" "foobar" {
-	description = "High Availablility for Foobar"
-
 	database {
 		position = "leader"
 		app_id = "%[1]s"

--- a/herokux/resource_herokux_postgres_test.go
+++ b/herokux/resource_herokux_postgres_test.go
@@ -18,8 +18,6 @@ func TestAccHerokuxPostgres_OnlyLeader(t *testing.T) {
 				Config: testAccCheckHerokuxPostgres_OnlyLeader(appID, plan),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
-						"herokux_postgres.foobar", "description", "High Availablility for Foobar"),
-					resource.TestCheckResourceAttr(
 						"herokux_postgres.foobar", "database.#", "1"),
 					//helper.TestCheckTypeSetElemAttr("herokux_postgres.foobar",
 					//	"allowed_accounts.*", "123456789123"),
@@ -40,8 +38,6 @@ func TestAccHerokuxPostgres_LeaderAndFollower(t *testing.T) {
 			{
 				Config: testAccCheckHerokuxPostgres_LeaderAndFollower(appID, plan),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"herokux_postgres.foobar", "description", "High Availablility for Foobar"),
 					resource.TestCheckResourceAttrSet(
 						"herokux_postgres.foobar", "database_leader_id"),
 					resource.TestCheckResourceAttrSet(

--- a/herokux/resource_herokux_postgres_test.go
+++ b/herokux/resource_herokux_postgres_test.go
@@ -1,0 +1,87 @@
+package herokux
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"testing"
+)
+
+func TestAccHerokuxPostgres_OnlyLeader(t *testing.T) {
+	appID := testAccConfig.GetAppIDorSkip(t)
+	plan := "private-0"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckHerokuxPostgres_OnlyLeader(appID, plan),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"herokux_postgres.foobar", "description", "High Availablility for Foobar"),
+					resource.TestCheckResourceAttr(
+						"herokux_postgres.foobar", "database.#", "1"),
+					//helper.TestCheckTypeSetElemAttr("herokux_postgres.foobar",
+					//	"allowed_accounts.*", "123456789123"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccHerokuxPostgres_LeaderAndFollower(t *testing.T) {
+	appID := testAccConfig.GetAppIDorSkip(t)
+	plan := "private-0"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckHerokuxPostgres_LeaderAndFollower(appID, plan),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"herokux_postgres.foobar", "description", "High Availablility for Foobar"),
+					resource.TestCheckResourceAttr(
+						"herokux_postgres.foobar", "database.#", "2"),
+					//helper.TestCheckTypeSetElemAttr("herokux_postgres.foobar",
+					//	"allowed_accounts.*", "123456789123"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckHerokuxPostgres_OnlyLeader(appID, plan string) string {
+	return fmt.Sprintf(`
+resource "herokux_postgres" "foobar" {
+	description = "High Availablility for Foobar"
+
+	database {
+		position = "leader"
+		app_id = "%s"
+		plan = "%s"
+	}
+}
+`, appID, plan)
+}
+
+func testAccCheckHerokuxPostgres_LeaderAndFollower(appID, plan string) string {
+	return fmt.Sprintf(`
+resource "herokux_postgres" "foobar" {
+	description = "High Availablility for Foobar"
+
+	database {
+		position = "leader"
+		app_id = "%[1]s"
+		plan = "%[2]s"
+	}
+
+	database {
+		position = "follower"
+		app_id = "%[1]s"
+		plan = "%[2]s"
+	}
+}
+`, appID, plan)
+}

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -105,6 +105,10 @@ The following arguments are supported:
 
 * `postgres_api_url` - (Optional) Custom Postgres API url
 
+* `data_api_url` - (Optional) Custom Data API url
+
+* `platform_api_url` - (Optional) Custom Platform API url
+
 * `headers` - (Optional) Additional API headers.
 
 * `timeouts` - (Optional) Timeouts help certain resources to be properly created or deleted before proceeding with further actions.


### PR DESCRIPTION
## Summary
This pull request aims to replicate a leader + follower postgres database [setup](https://devcenter.heroku.com/articles/heroku-postgres-follower-databases#create-a-follower).

## Specs
- Only can create one leader and one follower.
- This resource would not necessarily replace `heroku_addon` as version one is very basic.
- provider block that controls the `last commit behind before unfollowing`.
- promote vs unfollow | unfollow vs promote.

### Waits
- This resource requires the following polling mechanisms:
   - poll when the leader db is provisioned
   - poll when the follder db is provisioned (if applicable)
   - poll when the leader db is ready for followers
   - poll when the follower db is caught up with the leader for promotion
   - when the follower is `waiting?` set to `false` and `status` set to Available.

## Testing Scenarios:
- [x] Create just a leader
- [x] Create leader and follower
- [ ] Create leader and follower and promote follower. Follower should become leader and new follower launched to follow original follower.
- [ ] Import just a leader
- [ ] Import leader and follower
- [ ] What happens if there's already an existing database occupying "DATABASE_URL"?

## References
https://devcenter.heroku.com/articles/heroku-postgres-follower-databases#create-a-follower