### PR TITLE
New resource: `herokux_postgres_credential`

### DIFF
--- a/api/postgres/credential.go
+++ b/api/postgres/credential.go
@@ -1,0 +1,82 @@
+package postgres
+
+import "github.com/davidji99/simpleresty"
+
+// Credential represents a credential for a postgres database.
+//
+// The ID (UUID) cannot be used to retrieve a single credential. The name is required.
+type Credential struct {
+	ID          *string             `json:"uuid,omitempty"`
+	Name        *string             `json:"name,omitempty"`
+	State       CredentialState     `json:"state,omitempty"`
+	Database    *string             `json:"database,omitempty"`
+	Host        *string             `json:"host,omitempty"`
+	Port        *int                `json:"port,omitempty"`
+	Credentials []*CredentialSecret `json:"credentials,omitempty"`
+}
+
+// CredentialSecret represents the username & password for a Credential.
+type CredentialSecret struct {
+	User     *string `json:"user,omitempty"`
+	Password *string `json:"password,omitempty"`
+	State    *string `json:"state,omitempty"`
+}
+
+// ListCredentials retrieves all credentials for a database.
+func (p *Postgres) ListCredentials(dbNameOrID string) ([]*Credential, *simpleresty.Response, error) {
+	var result []*Credential
+	urlStr := p.http.RequestURL("/postgres/v0/databases/%s/credentials", dbNameOrID)
+
+	// Execute the request
+	response, getErr := p.http.Get(urlStr, &result, nil)
+
+	return result, response, getErr
+}
+
+// GetCredential retrieves a single credential for a database.
+func (p *Postgres) GetCredential(dbNameOrID, credentialName string) (*Credential, *simpleresty.Response, error) {
+	var result *Credential
+	urlStr := p.http.RequestURL("/postgres/v0/databases/%s/credentials/%s", dbNameOrID, credentialName)
+
+	// Execute the request
+	response, getErr := p.http.Get(urlStr, &result, nil)
+
+	return result, response, getErr
+}
+
+// CreateCredential creates a postgres database credential.
+//
+// Returns a GenericResponse.
+func (p *Postgres) CreateCredential(dbNameOrID, newCredName string) (*GenericResponse, *simpleresty.Response, error) {
+	var result *GenericResponse
+	urlStr := p.http.RequestURL("/postgres/v0/databases/%s/credentials", dbNameOrID)
+
+	body := struct {
+		Name string `json:"name"`
+	}{
+		Name: newCredName,
+	}
+
+	// Execute the request
+	response, getErr := p.http.Post(urlStr, &result, &body)
+
+	return result, response, getErr
+}
+
+// DeleteCredential revokes and deletes a credential. Please make sure to first check if the credential is attached
+// to any existing addons.
+//
+// Returns a GenericResponse with a message of the following:
+//  - The credential from_api has been destroyed within postgresql-fluffy-50793 and detached from all apps.
+//
+// Note: it takes a bit of time before the credential is fully deleted. The username/password are first to be deleted
+// and then the credential itself is deleted.
+func (p *Postgres) DeleteCredential(dbNameOrID, credentialName string) (*GenericResponse, *simpleresty.Response, error) {
+	var result *GenericResponse
+	urlStr := p.http.RequestURL("/postgres/v0/databases/%s/credentials/%s", dbNameOrID, credentialName)
+
+	// Execute the request
+	response, getErr := p.http.Delete(urlStr, &result, nil)
+
+	return result, response, getErr
+}

--- a/api/postgres/postgres-accessors.go
+++ b/api/postgres/postgres-accessors.go
@@ -9,6 +9,81 @@ import (
 	"time"
 )
 
+// HasCredentials checks if Credential has any Credentials.
+func (c *Credential) HasCredentials() bool {
+	if c == nil || c.Credentials == nil {
+		return false
+	}
+	if len(c.Credentials) == 0 {
+		return false
+	}
+	return true
+}
+
+// GetDatabase returns the Database field if it's non-nil, zero value otherwise.
+func (c *Credential) GetDatabase() string {
+	if c == nil || c.Database == nil {
+		return ""
+	}
+	return *c.Database
+}
+
+// GetHost returns the Host field if it's non-nil, zero value otherwise.
+func (c *Credential) GetHost() string {
+	if c == nil || c.Host == nil {
+		return ""
+	}
+	return *c.Host
+}
+
+// GetID returns the ID field if it's non-nil, zero value otherwise.
+func (c *Credential) GetID() string {
+	if c == nil || c.ID == nil {
+		return ""
+	}
+	return *c.ID
+}
+
+// GetName returns the Name field if it's non-nil, zero value otherwise.
+func (c *Credential) GetName() string {
+	if c == nil || c.Name == nil {
+		return ""
+	}
+	return *c.Name
+}
+
+// GetPort returns the Port field if it's non-nil, zero value otherwise.
+func (c *Credential) GetPort() int {
+	if c == nil || c.Port == nil {
+		return 0
+	}
+	return *c.Port
+}
+
+// GetPassword returns the Password field if it's non-nil, zero value otherwise.
+func (c *CredentialSecret) GetPassword() string {
+	if c == nil || c.Password == nil {
+		return ""
+	}
+	return *c.Password
+}
+
+// GetState returns the State field if it's non-nil, zero value otherwise.
+func (c *CredentialSecret) GetState() string {
+	if c == nil || c.State == nil {
+		return ""
+	}
+	return *c.State
+}
+
+// GetUser returns the User field if it's non-nil, zero value otherwise.
+func (c *CredentialSecret) GetUser() string {
+	if c == nil || c.User == nil {
+		return ""
+	}
+	return *c.User
+}
+
 // GetAddonID returns the AddonID field if it's non-nil, zero value otherwise.
 func (d *Database) GetAddonID() string {
 	if d == nil || d.AddonID == nil {

--- a/api/postgres/types.go
+++ b/api/postgres/types.go
@@ -122,3 +122,28 @@ var DataConnectorStatuses = struct {
 func (s DataConnectorStatus) ToString() string {
 	return string(s)
 }
+
+// CredentialState represents the status of a postgres credential.
+type CredentialState string
+
+// CredentialStates represent all statuses pertaining to the lifecycle of a postgres credential.
+var CredentialStates = struct {
+	PROVISIONING        CredentialState
+	WAITFORPROVISIONING CredentialState
+	ACTIVE              CredentialState
+	REVOKING            CredentialState
+	DELETED             CredentialState
+	UNKNOWN             CredentialState
+}{
+	ACTIVE:              "active",
+	WAITFORPROVISIONING: "wait_for_provisioning",
+	PROVISIONING:        "provisioning",
+	REVOKING:            "revoking",
+	DELETED:             "DELETED",
+	UNKNOWN:             "unknown",
+}
+
+// ToString is a helper method to return the string of a CredentialState.
+func (s CredentialState) ToString() string {
+	return string(s)
+}

--- a/herokux/config.go
+++ b/herokux/config.go
@@ -33,6 +33,8 @@ const (
 	DefaultDataConnectorCreateTimeout              = int64(10)
 	DefaultDataConnectorDeleteTimeout              = int64(10)
 	DefaultDataConnectorUpdateTimeout              = int64(10)
+	DefaultPostgresCredentialCreateTimeout         = int64(10)
+	DefaultPostgresCredentialDeleteTimeout         = int64(10)
 )
 
 type Config struct {
@@ -62,6 +64,8 @@ type Config struct {
 	DataConnectorCreateTimeout              int64
 	DataConnectorDeleteTimeout              int64
 	DataConnectorUpdateTimeout              int64
+	PostgresCredentialCreateTimeout         int64
+	PostgresCredentialDeleteTimeout         int64
 }
 
 func NewConfig() *Config {
@@ -82,6 +86,8 @@ func NewConfig() *Config {
 		DataConnectorCreateTimeout:              DefaultDataConnectorCreateTimeout,
 		DataConnectorDeleteTimeout:              DefaultDataConnectorDeleteTimeout,
 		DataConnectorUpdateTimeout:              DefaultDataConnectorUpdateTimeout,
+		PostgresCredentialCreateTimeout:         DefaultPostgresCredentialCreateTimeout,
+		PostgresCredentialDeleteTimeout:         DefaultPostgresCredentialDeleteTimeout,
 	}
 	return c
 }
@@ -214,6 +220,14 @@ func (c *Config) applySchema(d *schema.ResourceData) (err error) {
 
 			if v, ok := delaysConfig["data_connector_update_timeout"].(int); ok {
 				c.DataConnectorUpdateTimeout = int64(v)
+			}
+
+			if v, ok := delaysConfig["postgres_credential_create_timeout"].(int); ok {
+				c.PostgresCredentialCreateTimeout = int64(v)
+			}
+
+			if v, ok := delaysConfig["postgres_credential_delete_timeout"].(int); ok {
+				c.PostgresCredentialDeleteTimeout = int64(v)
 			}
 		}
 	}

--- a/herokux/import_herokux_postgres_credential_test.go
+++ b/herokux/import_herokux_postgres_credential_test.go
@@ -1,0 +1,31 @@
+package herokux
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"testing"
+)
+
+func TestAccHerokuxPostgresCredential_importBasic(t *testing.T) {
+	postgresID := testAccConfig.GetAddonIDorSkip(t)
+	name := fmt.Sprintf("tftest-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckHerokuxPostgresCredential_basic(postgresID, name),
+			},
+			{
+				ResourceName:      "herokux_postgres_credential.foobar",
+				ImportStateId:     fmt.Sprintf("%s:%s", postgresID, name),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/herokux/provider.go
+++ b/herokux/provider.go
@@ -168,6 +168,20 @@ func New() *schema.Provider {
 							Default:      10,
 							ValidateFunc: validation.IntAtLeast(5),
 						},
+
+						"postgres_credential_create_timeout": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Default:      10,
+							ValidateFunc: validation.IntAtLeast(5),
+						},
+
+						"postgres_credential_delete_timeout": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Default:      10,
+							ValidateFunc: validation.IntAtLeast(5),
+						},
 					},
 				},
 			},
@@ -182,6 +196,7 @@ func New() *schema.Provider {
 			"herokux_formation_autoscaling":     resourceHerokuxFormationAutoscaling(),
 			"herokux_kafka_consumer_group":      resourceHerokuxKafkaConsumerGroup(),
 			"herokux_kafka_topic":               resourceHerokuxKafkaTopic(),
+			"herokux_postgres_credential":       resourceHerokuxPostgresCredential(),
 			"herokux_postgres_mtls":             resourceHerokuxPostgresMTLS(),
 			"herokux_postgres_mtls_certificate": resourceHerokuxPostgresMTLSCertificate(),
 			"herokux_postgres_mtls_iprule":      resourceHerokuxPostgresMTLSIPRule(),

--- a/herokux/resource_herokux_kafka_topic.go
+++ b/herokux/resource_herokux_kafka_topic.go
@@ -178,7 +178,7 @@ func resourceHerokuxKafkaTopicCreate(ctx context.Context, d *schema.ResourceData
 		Target:       []string{kafka.TopicStatuses.READY.ToString()},
 		Refresh:      topicCreationStateRefreshFunc(client, kafkaID, opts.Name, opts.Partitions),
 		Timeout:      time.Duration(config.KafkaTopicCreateTimeout) * time.Minute,
-		PollInterval: 5 * time.Second,
+		PollInterval: 10 * time.Second,
 	}
 
 	if _, err := stateConf.WaitForStateContext(ctx); err != nil {

--- a/herokux/resource_herokux_postgres_credential.go
+++ b/herokux/resource_herokux_postgres_credential.go
@@ -1,0 +1,287 @@
+package herokux
+
+import (
+	"context"
+	"fmt"
+	"github.com/davidji99/terraform-provider-herokux/api"
+	"github.com/davidji99/terraform-provider-herokux/api/postgres"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"log"
+	"regexp"
+	"strings"
+	"time"
+)
+
+const (
+	ValidCredentialNameRegex = `^[a-zA-Z0-9_-]{1,50}$`
+)
+
+func resourceHerokuxPostgresCredential() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceHerokuxPostgresCredentialCreate,
+		ReadContext:   resourceHerokuxPostgresCredentialRead,
+		DeleteContext: resourceHerokuxPostgresCredentialDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceHerokuxPostgresCredentialImport,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"postgres_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.IsUUID,
+			},
+
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateCredentialName,
+			},
+
+			"state": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"database": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"host": {
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
+
+			"port": {
+				Type:      schema.TypeInt,
+				Computed:  true,
+				Sensitive: true,
+			},
+
+			"secrets": {
+				Type:      schema.TypeList,
+				Computed:  true,
+				Sensitive: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"username": {
+							Type:      schema.TypeString,
+							Sensitive: true,
+							Computed:  true,
+						},
+
+						"password": {
+							Type:      schema.TypeString,
+							Sensitive: true,
+							Computed:  true,
+						},
+
+						"state": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+
+			"uuid": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func validateCredentialName(v interface{}, k string) (ws []string, errors []error) {
+	name := v.(string)
+	if !regexp.MustCompile(ValidCredentialNameRegex).MatchString(name) {
+		errors = append(errors, fmt.Errorf("invalid name: name is restricted to alphanumeric characters(- and _ are also supported) and up to 50 characters"))
+	}
+
+	return
+}
+
+func resourceHerokuxPostgresCredentialImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	// Check to make sure the credential name is not 'default' as the 'default' credential cannot be destroyed.
+	result, parseErr := parseCompositeID(d.Id(), 2)
+	if parseErr != nil {
+		return nil, parseErr
+	}
+
+	credName := result[1]
+
+	if strings.ToLower(credName) == "default" {
+		return nil, fmt.Errorf("cannot import the 'default' credential")
+	}
+
+	d.SetId(d.Id())
+
+	readErr := resourceHerokuxPostgresCredentialRead(ctx, d, meta)
+	if readErr.HasError() {
+		return nil, fmt.Errorf("unable to import this credential")
+	}
+
+	return []*schema.ResourceData{d}, nil
+}
+
+func resourceHerokuxPostgresCredentialCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*Config)
+	client := config.API
+
+	var postgresID, name string
+	if v, ok := d.GetOk("name"); ok {
+		name = v.(string)
+		log.Printf("[DEBUG] credential name is : %v", name)
+	}
+
+	if v, ok := d.GetOk("postgres_id"); ok {
+		postgresID = v.(string)
+		log.Printf("[DEBUG] credential postgres_id is : %v", postgresID)
+	}
+
+	log.Printf("[DEBUG] Creating postgres credential %s", name)
+
+	_, _, createErr := client.Postgres.CreateCredential(postgresID, name)
+	if createErr != nil {
+		return diag.FromErr(createErr)
+	}
+
+	log.Printf("[DEBUG] Waiting for postgres credential %s to be active", name)
+
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{postgres.CredentialStates.WAITFORPROVISIONING.ToString(),
+			postgres.CredentialStates.PROVISIONING.ToString()},
+		Target:       []string{postgres.CredentialStates.ACTIVE.ToString()},
+		Refresh:      postgresCredentialCreationStateRefreshFunc(client, postgresID, name),
+		Timeout:      time.Duration(config.PostgresCredentialCreateTimeout) * time.Minute,
+		PollInterval: 10 * time.Second,
+	}
+
+	if _, err := stateConf.WaitForStateContext(ctx); err != nil {
+		return diag.Errorf("error waiting for postgres credential %s to be active on %s: %s", name, postgresID, err.Error())
+	}
+
+	// Set the ID to be a composite of the postgres ID and the credential name.
+	d.SetId(fmt.Sprintf("%s:%s", postgresID, name))
+
+	return resourceHerokuxPostgresCredentialRead(ctx, d, meta)
+}
+
+func resourceHerokuxPostgresCredentialRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*Config).API
+
+	result, parseErr := parseCompositeID(d.Id(), 2)
+	if parseErr != nil {
+		return diag.FromErr(parseErr)
+	}
+
+	postgresID := result[0]
+	credName := result[1]
+
+	cred, _, getErr := client.Postgres.GetCredential(postgresID, credName)
+	if getErr != nil {
+		return diag.FromErr(getErr)
+	}
+
+	d.Set("postgres_id", postgresID)
+	d.Set("name", cred.GetName())
+	d.Set("state", cred.State.ToString())
+	d.Set("database", cred.GetDatabase())
+	d.Set("host", cred.GetHost())
+	d.Set("port", cred.GetPort())
+	d.Set("uuid", cred.GetID())
+
+	// Construct secrets attribute
+	secrets := make([]interface{}, 0)
+	for _, s := range cred.Credentials {
+		c := make(map[string]interface{})
+		c["username"] = s.GetUser()
+		c["password"] = s.GetPassword()
+		c["state"] = s.GetState()
+
+		secrets = append(secrets, c)
+	}
+
+	d.Set("secrets", secrets)
+
+	return nil
+}
+
+func resourceHerokuxPostgresCredentialDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*Config)
+	client := config.API
+
+	result, parseErr := parseCompositeID(d.Id(), 2)
+	if parseErr != nil {
+		return diag.FromErr(parseErr)
+	}
+
+	postgresID := result[0]
+	credName := result[1]
+
+	log.Printf("[DEBUG] Deleting postgres credential %s", credName)
+
+	_, _, deleteErr := client.Postgres.DeleteCredential(postgresID, credName)
+	if deleteErr != nil {
+		return diag.FromErr(deleteErr)
+	}
+
+	log.Printf("[DEBUG] Waiting for postgres credential %s to be deleted", credName)
+
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{postgres.CredentialStates.REVOKING.ToString()},
+		Target:       []string{postgres.CredentialStates.DELETED.ToString()},
+		Refresh:      postgresCredentialDeletionStateRefreshFunc(client, postgresID, credName),
+		Timeout:      time.Duration(config.PostgresCredentialDeleteTimeout) * time.Minute,
+		PollInterval: 10 * time.Second,
+	}
+
+	if _, err := stateConf.WaitForStateContext(ctx); err != nil {
+		return diag.Errorf("error waiting for postgres credential %s to be deleted on %s: %s", credName, postgresID, err.Error())
+	}
+
+	return nil
+}
+
+func postgresCredentialCreationStateRefreshFunc(client *api.Client, postgresID, credName string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		cred, _, getErr := client.Postgres.GetCredential(postgresID, credName)
+		if getErr != nil {
+			return nil, postgres.CredentialStates.UNKNOWN.ToString(), getErr
+		}
+
+		if cred.State == postgres.CredentialStates.WAITFORPROVISIONING {
+			log.Printf("[DEBUG] postgres credential %s not yet active", cred.GetName())
+			return cred, cred.State.ToString(), nil
+		}
+
+		return cred, cred.State.ToString(), nil
+	}
+}
+
+func postgresCredentialDeletionStateRefreshFunc(client *api.Client, postgresID, credName string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		cred, response, getErr := client.Postgres.GetCredential(postgresID, credName)
+		if getErr != nil {
+			if response.StatusCode == 404 {
+				return postgres.Credential{}, postgres.CredentialStates.DELETED.ToString(), nil
+			}
+			return nil, postgres.CredentialStates.UNKNOWN.ToString(), getErr
+		}
+
+		if cred.State == postgres.CredentialStates.REVOKING {
+			log.Printf("[DEBUG] postgres credential %s not yet deleted", cred.GetName())
+			return cred, cred.State.ToString(), nil
+		}
+
+		return cred, postgres.CredentialStates.UNKNOWN.ToString(), fmt.Errorf("credential not properly deleted")
+	}
+}

--- a/herokux/resource_herokux_postgres_credential_test.go
+++ b/herokux/resource_herokux_postgres_credential_test.go
@@ -1,0 +1,50 @@
+package herokux
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"testing"
+)
+
+func TestAccHerokuxPostgresCredential_Basic(t *testing.T) {
+	postgresID := testAccConfig.GetAddonIDorSkip(t)
+	name := fmt.Sprintf("tftest-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckHerokuxPostgresCredential_basic(postgresID, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"herokux_postgres_credential.foobar", "postgres_id", postgresID),
+					resource.TestCheckResourceAttr(
+						"herokux_postgres_credential.foobar", "name", name),
+					resource.TestCheckResourceAttr(
+						"herokux_postgres_credential.foobar", "state", "active"),
+					resource.TestCheckResourceAttrSet(
+						"herokux_postgres_credential.foobar", "database"),
+					resource.TestCheckResourceAttrSet(
+						"herokux_postgres_credential.foobar", "host"),
+					resource.TestCheckResourceAttrSet(
+						"herokux_postgres_credential.foobar", "port"),
+					resource.TestCheckResourceAttrSet(
+						"herokux_postgres_credential.foobar", "uuid"),
+					resource.TestCheckResourceAttr(
+						"herokux_postgres_credential.foobar", "secrets.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckHerokuxPostgresCredential_basic(postgresID, name string) string {
+	return fmt.Sprintf(`
+resource "herokux_postgres_credential" "foobar" {
+	postgres_id = "%s"
+	name = "%s"
+}
+`, postgresID, name)
+}

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -160,3 +160,9 @@ Only a single `timeouts` block may be specified and it supports the following ar
 
   * `data_connector_update_timeout` - (Optional) The number of minutes to wait for a data connector to be updated.
   Defaults to 10 minutes. Minimum required is 5 minutes.
+
+  * `postgres_credential_create_timeout` - (Optional) The number of minutes to wait for a postgres credential to be created.
+  Defaults to 10 minutes. Minimum required is 5 minutes.
+
+  * `postgres_credential_delete_timeout` - (Optional) The number of minutes to wait for a postgres credential to be deleted.
+  Defaults to 10 minutes. Minimum required is 5 minutes.

--- a/website/docs/r/postgres_credential.html.markdown
+++ b/website/docs/r/postgres_credential.html.markdown
@@ -1,0 +1,88 @@
+---
+layout: "herokux"
+page_title: "HerokuX: herokux_postgres_credential"
+sidebar_current: "docs-herokux-resource-postgres-credential"
+description: |-
+  Provides a resource to manage a credential of a postgres database
+---
+
+# herokux\_postgres\_credential
+
+This resource manages credentials for a Heroku postgres database. [Credentials](https://devcenter.heroku.com/articles/heroku-postgresql-credentials)
+represent Heroku's management layer around postgres roles. Each credential corresponds to a different
+Postgres role and its specific set of database privileges.
+
+Credentials created by this resource do not have any permissions by default. To grant permissions to a credential,
+please use the Heroku CLI (`heroku pg:psql`) or visit the UI for further action.
+
+-> **IMPORTANT!**
+Please be very careful when deleting this resource as any deleted credentials are NOT recoverable and invalidated immediately.
+Furthermore, this resource renders the `secrets.username` & `secrets.password` attributes in plain-text in your state file.
+Please ensure that your state file is properly secured and encrypted at rest.
+
+### Resource Timeouts
+During creation and deletion, this resource checks the status of the credential. All the aforementioned timeouts
+can be customized via `timeouts.postgres_credential_create_timeout` and
+`timeouts.postgres_credential_delete_timeout` in your `provider` block.
+
+For example:
+```hcl-terraform
+provider "herokux" {
+  timeouts {
+    postgres_credential_create_timeout = 20
+    postgres_credential_delete_timeout = 20
+  }
+}
+```
+
+## Example Usage
+
+```hcl-terraform
+resource "herokux_postgres_credential" "foobar" {
+	postgres_id = "SOME_POSTGRES_ID"
+	name = "read-only-credential"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `postgres_id` - (Required) `<string>` The UUID of a Heroku postgres addon.
+
+* `name` - (Required) `<string>` Name of the credential. Credential names are restricted to alphanumeric characters
+(`-` and `_` are supported) and cannot be longer than 50 characters. Names are not an updatable attribute and will
+force and destroy and create flow if changed.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `state` - The state of credential.
+
+* `database` - The name of the database that the credential belongs to.
+
+* `host` - The database host URL. This attribute value does not get displayed in logs or regular output.
+
+* `port` - The database port number. This attribute value does not get displayed in logs or regular output.
+
+* `secrets` - List of maps of usernames and passwords for the credential. By default, there will be always be at least
+one set of a username and password. This attribute value does not get displayed in logs or regular output.
+    * `username` - The username. This attribute value does not get displayed in logs or regular output.
+    * `password` - The password. This attribute value does not get displayed in logs or regular output.
+    * `state` - The state of the secret.
+
+* `uuid` - The UUID for the credential.
+
+## Import
+
+An existing credential can be imported using a composite value
+of the postgres ID and credential name separated by a colon.
+
+For example:
+```shell script
+$ terraform import herokux_postgres_credential.foobar "<POSTGRES_ID>:<CREDENTIAL_NAME>"
+```
+
+**Please Note:** DO NOT import the 'default' credential provisioned with every new Heroku postgres database.
+Heroku does not allow you to destroy this credential, so it will not be possible manage it via Terraform.

--- a/website/herokux.erb
+++ b/website/herokux.erb
@@ -37,6 +37,10 @@
                   <a href="/docs/providers/herokux/r/kafka_topic.html">herokux_kafka_topic</a>
                 </li>
 
+                <li<%= sidebar_current("docs-herokux-resource-postgres-credential") %>>
+                  <a href="/docs/providers/herokux/r/postgres_credential.html">herokux_postgres_credential</a>
+                </li>
+
                 <li<%= sidebar_current("docs-herokux-resource-postgres-mtls") %>>
                   <a href="/docs/providers/herokux/r/postgres_mtls.html">herokux_postgres_mtls</a>
                 </li>


### PR DESCRIPTION
https://devcenter.heroku.com/articles/heroku-postgresql-credentials

New resource CREATE & DELETE only. There's no update. The permissions is backed by GRAPHQL so a bit tricky.

```hcl
resource "herokux_postgres_credential" "foobar" {
    postgres_id = "UUID"
    name = "limited_user"
}
```

Notes:
- docs should indicate this resource should NOT be used to import the `default` credential.