### PR TITLE
standardize state frequency polling multiplier

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -34,6 +34,7 @@ The following parameters are available for running the test. The absence of some
 * **TF_ACC** (`integer`) **Required** - must be set to `1`.
 * **HEROKU_API_KEY** (`string`) **Required**  - A valid Heroku API key.
 * **HEROKUX_APP_ID** (`string`) - The UUID of an existing app.
+* **HEROKUX_ADDON_ID** (`string`) - The UUID of an existing addon. Use this for postgres addon IDs.
 * **HEROKUX_DB_NAME** (`string`) - The name of an existing postgres database.
 * **HEROKUX_KAFKA_ID** (`string`) - The UUID of an existing Kafka addon.
 

--- a/herokux/provider.go
+++ b/herokux/provider.go
@@ -8,6 +8,17 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	heroku "github.com/heroku/heroku-go/v5"
 	"log"
+	"time"
+)
+
+const (
+	// StateRefreshPollIntervalFrequency defines the polling frequency.
+	StateRefreshPollIntervalFrequency = 20
+)
+
+var (
+	// StateRefreshPollInterval defines the default polling interval in seconds.
+	StateRefreshPollInterval = StateRefreshPollIntervalFrequency * time.Second
 )
 
 func New() *schema.Provider {

--- a/herokux/resource_herokux_data_connector.go
+++ b/herokux/resource_herokux_data_connector.go
@@ -177,7 +177,7 @@ func resourceHerokuxDataConnectorCreate(ctx context.Context, d *schema.ResourceD
 		Target:       []string{postgres.DataConnectorStatuses.AVAILABLE.ToString()},
 		Refresh:      DataConnectorCreateStateRefreshFunc(client, dc.GetID()),
 		Timeout:      time.Duration(config.DataConnectorCreateTimeout) * time.Minute,
-		PollInterval: 20 * time.Second,
+		PollInterval: StateRefreshPollInterval,
 	}
 
 	if _, err := stateConf.WaitForStateContext(ctx); err != nil {
@@ -318,7 +318,7 @@ func pauseResumeDataConnector(ctx context.Context, d *schema.ResourceData, meta 
 		Target:       []string{targetState},
 		Refresh:      DataConnectorStateRefreshFunc(client, d.Id(), pendingState, targetState),
 		Timeout:      time.Duration(config.DataConnectorUpdateTimeout) * time.Minute,
-		PollInterval: 20 * time.Second,
+		PollInterval: StateRefreshPollInterval,
 	}
 
 	if _, err := stateConf.WaitForStateContext(ctx); err != nil {
@@ -346,7 +346,7 @@ func resourceHerokuxDataConnectorDelete(ctx context.Context, d *schema.ResourceD
 		Target:       []string{postgres.DataConnectorStatuses.DELETED.ToString()},
 		Refresh:      DataConnectorDeleteStateRefreshFunc(client, d.Id()),
 		Timeout:      time.Duration(config.DataConnectorDeleteTimeout) * time.Minute,
-		PollInterval: 10 * time.Second,
+		PollInterval: StateRefreshPollInterval,
 	}
 
 	if _, err := stateConf.WaitForStateContext(ctx); err != nil {

--- a/herokux/resource_herokux_kafka_consumer_group.go
+++ b/herokux/resource_herokux_kafka_consumer_group.go
@@ -76,7 +76,7 @@ func resourceHerokuxKafkaConsumerGroupCreate(ctx context.Context, d *schema.Reso
 		Refresh: kafkaConsumerGroupStateRefreshFunc(kafkaID, opts.Name,
 			kafka.ConsumerGroupStatuses.CREATED, client.Kafka.WasConsumerGroupCreated),
 		Timeout:      time.Duration(config.KafkaCGCreateTimeout) * time.Minute,
-		PollInterval: 5 * time.Second,
+		PollInterval: StateRefreshPollInterval,
 	}
 
 	if _, err := stateConf.WaitForStateContext(ctx); err != nil {
@@ -136,7 +136,7 @@ func resourceHerokuxKafkaConsumerGroupDelete(ctx context.Context, d *schema.Reso
 		Refresh: kafkaConsumerGroupStateRefreshFunc(result[0], result[1],
 			kafka.ConsumerGroupStatuses.DELETED, client.Kafka.WasConsumerGroupDeleted),
 		Timeout:      time.Duration(config.KafkaCGDeleteTimeout) * time.Minute,
-		PollInterval: 5 * time.Second,
+		PollInterval: StateRefreshPollInterval,
 	}
 
 	if _, err := stateConf.WaitForStateContext(ctx); err != nil {

--- a/herokux/resource_herokux_kafka_topic.go
+++ b/herokux/resource_herokux_kafka_topic.go
@@ -178,7 +178,7 @@ func resourceHerokuxKafkaTopicCreate(ctx context.Context, d *schema.ResourceData
 		Target:       []string{kafka.TopicStatuses.READY.ToString()},
 		Refresh:      topicCreationStateRefreshFunc(client, kafkaID, opts.Name, opts.Partitions),
 		Timeout:      time.Duration(config.KafkaTopicCreateTimeout) * time.Minute,
-		PollInterval: 10 * time.Second,
+		PollInterval: StateRefreshPollInterval,
 	}
 
 	if _, err := stateConf.WaitForStateContext(ctx); err != nil {
@@ -326,7 +326,7 @@ func resourceHerokuxKafkaTopicUpdate(ctx context.Context, d *schema.ResourceData
 		Target:       []string{kafka.TopicStatuses.UPDATED.ToString()},
 		Refresh:      topicUpdateStateRefreshFunc(client, kafkaID, opts.Name, checkFuncs),
 		Timeout:      time.Duration(config.KafkaTopicCreateTimeout) * time.Minute,
-		PollInterval: 5 * time.Second,
+		PollInterval: StateRefreshPollInterval,
 	}
 
 	if _, err := stateConf.WaitForStateContext(ctx); err != nil {

--- a/herokux/resource_herokux_postgres.go
+++ b/herokux/resource_herokux_postgres.go
@@ -218,10 +218,10 @@ func resourceHerokuxPostgresCreate(ctx context.Context, d *schema.ResourceData, 
 	// Wait for the database leader to be provisioned
 	log.Printf("[INFO] Waiting for database leader ID (%s) to be provisioned", leaderDB.ID)
 	leaderStateConf := &resource.StateChangeConf{
-		Pending: []string{"provisioning"},
-		Target:  []string{"provisioned"},
-		Refresh: AddOnStateRefreshFunc(platformAPI, leaderDB.ID),
-		Timeout: 20 * time.Minute,
+		Pending:      []string{"provisioning"},
+		Target:       []string{"provisioned"},
+		Refresh:      AddOnStateRefreshFunc(platformAPI, leaderDB.ID),
+		Timeout:      20 * time.Minute,
 		PollInterval: StateRefreshPollInterval,
 	}
 
@@ -263,10 +263,10 @@ func resourceHerokuxPostgresCreate(ctx context.Context, d *schema.ResourceData, 
 		// Wait for the database leader to be provisioned
 		log.Printf("[INFO] Waiting for database follower ID (%s) to be provisioned", followerDB.ID)
 		followerStateConf := &resource.StateChangeConf{
-			Pending: []string{"provisioning"},
-			Target:  []string{"provisioned"},
-			Refresh: AddOnStateRefreshFunc(platformAPI, followerDB.ID),
-			Timeout: 20 * time.Minute,
+			Pending:      []string{"provisioning"},
+			Target:       []string{"provisioned"},
+			Refresh:      AddOnStateRefreshFunc(platformAPI, followerDB.ID),
+			Timeout:      20 * time.Minute,
 			PollInterval: StateRefreshPollInterval,
 		}
 

--- a/herokux/resource_herokux_postgres.go
+++ b/herokux/resource_herokux_postgres.go
@@ -222,6 +222,7 @@ func resourceHerokuxPostgresCreate(ctx context.Context, d *schema.ResourceData, 
 		Target:  []string{"provisioned"},
 		Refresh: AddOnStateRefreshFunc(platformAPI, leaderDB.ID),
 		Timeout: 20 * time.Minute,
+		PollInterval: StateRefreshPollInterval,
 	}
 
 	if _, err := leaderStateConf.WaitForStateContext(ctx); err != nil {
@@ -266,6 +267,7 @@ func resourceHerokuxPostgresCreate(ctx context.Context, d *schema.ResourceData, 
 			Target:  []string{"provisioned"},
 			Refresh: AddOnStateRefreshFunc(platformAPI, followerDB.ID),
 			Timeout: 20 * time.Minute,
+			PollInterval: StateRefreshPollInterval,
 		}
 
 		if _, err := followerStateConf.WaitForStateContext(ctx); err != nil {

--- a/herokux/resource_herokux_postgres_credential.go
+++ b/herokux/resource_herokux_postgres_credential.go
@@ -162,7 +162,7 @@ func resourceHerokuxPostgresCredentialCreate(ctx context.Context, d *schema.Reso
 		Target:       []string{postgres.CredentialStates.ACTIVE.ToString()},
 		Refresh:      postgresCredentialCreationStateRefreshFunc(client, postgresID, name),
 		Timeout:      time.Duration(config.PostgresCredentialCreateTimeout) * time.Minute,
-		PollInterval: 10 * time.Second,
+		PollInterval: StateRefreshPollInterval,
 	}
 
 	if _, err := stateConf.WaitForStateContext(ctx); err != nil {
@@ -241,7 +241,7 @@ func resourceHerokuxPostgresCredentialDelete(ctx context.Context, d *schema.Reso
 		Target:       []string{postgres.CredentialStates.DELETED.ToString()},
 		Refresh:      postgresCredentialDeletionStateRefreshFunc(client, postgresID, credName),
 		Timeout:      time.Duration(config.PostgresCredentialDeleteTimeout) * time.Minute,
-		PollInterval: 10 * time.Second,
+		PollInterval: StateRefreshPollInterval,
 	}
 
 	if _, err := stateConf.WaitForStateContext(ctx); err != nil {

--- a/herokux/resource_herokux_postgres_mtls.go
+++ b/herokux/resource_herokux_postgres_mtls.go
@@ -89,7 +89,7 @@ func resourceHerokuxPostgresMTLSProvision(ctx context.Context, d *schema.Resourc
 		Target:       []string{postgres.MTLSConfigStatuses.OPERATIONAL.ToString()},
 		Refresh:      MTLSSCreationStateRefreshFunc(client, dbName),
 		Timeout:      time.Duration(config.MTLSProvisionTimeout) * time.Minute,
-		PollInterval: 15 * time.Second,
+		PollInterval: StateRefreshPollInterval,
 	}
 
 	if _, err := stateConf.WaitForStateContext(ctx); err != nil {
@@ -162,7 +162,7 @@ func resourceHerokuxPostgresMTLSDeprovision(ctx context.Context, d *schema.Resou
 		Target:       []string{postgres.MTLSConfigStatuses.DEPROVISIONED.ToString()},
 		Refresh:      MTLSDeletionStateRefreshFunc(client, d.Id()),
 		Timeout:      time.Duration(config.MTLSDeprovisionTimeout) * time.Minute,
-		PollInterval: 15 * time.Second,
+		PollInterval: StateRefreshPollInterval,
 	}
 
 	if _, err := stateConf.WaitForStateContext(ctx); err != nil {

--- a/herokux/resource_herokux_postgres_mtls_certificate.go
+++ b/herokux/resource_herokux_postgres_mtls_certificate.go
@@ -116,7 +116,7 @@ func resourceHerokuxPostgresMTLSCertificateCreate(ctx context.Context, d *schema
 		Target:       []string{postgres.MTLSCertStatuses.READY.ToString()},
 		Refresh:      MTLSSCertStateRefreshFunc(client, dbName, cert.GetID()),
 		Timeout:      time.Duration(config.MTLSCertificateCreateTimeout) * time.Minute,
-		PollInterval: 15 * time.Second,
+		PollInterval: StateRefreshPollInterval,
 	}
 
 	if _, err := stateConf.WaitForStateContext(ctx); err != nil {
@@ -181,7 +181,7 @@ func resourceHerokuxPostgresMTLSCertificateDelete(ctx context.Context, d *schema
 		Target:       []string{postgres.MTLSCertStatuses.DISABLED.ToString()},
 		Refresh:      MTLSCertificateDeletionStateRefreshFunc(client, dbName, certID),
 		Timeout:      time.Duration(config.MTLSCertificateDeleteTimeout) * time.Minute,
-		PollInterval: 15 * time.Second,
+		PollInterval: StateRefreshPollInterval,
 	}
 
 	if _, err := stateConf.WaitForStateContext(ctx); err != nil {

--- a/herokux/resource_herokux_postgres_mtls_iprule.go
+++ b/herokux/resource_herokux_postgres_mtls_iprule.go
@@ -129,7 +129,7 @@ func resourceHerokuxPostgresMTLSIPRuleCreate(ctx context.Context, d *schema.Reso
 		Target:       []string{postgres.MTLSIPRuleStatuses.AUTHORIZED.ToString()},
 		Refresh:      MTLSSIPRuleStateRefreshFunc(client, dbName, ipRule.GetID()),
 		Timeout:      time.Duration(config.MTLSIPRuleCreateTimeout) * time.Minute,
-		PollInterval: 15 * time.Second,
+		PollInterval: StateRefreshPollInterval,
 	}
 
 	if _, err := stateConf.WaitForStateContext(ctx); err != nil {

--- a/herokux/resource_herokux_privatelink.go
+++ b/herokux/resource_herokux_privatelink.go
@@ -98,7 +98,7 @@ func resourceHerokuxPrivatelinkCreate(ctx context.Context, d *schema.ResourceDat
 		Target:       []string{data.PrivatelinkStatuses.OPERATIONAL.ToString()},
 		Refresh:      PrivatelinkCreateStateRefreshFunc(client, addonID),
 		Timeout:      time.Duration(config.PrivatelinkCreateTimeout) * time.Minute,
-		PollInterval: 15 * time.Second,
+		PollInterval: StateRefreshPollInterval,
 	}
 
 	if _, err := stateConf.WaitForStateContext(ctx); err != nil {
@@ -198,7 +198,7 @@ func resourceHerokuxPrivatelinkUpdate(ctx context.Context, d *schema.ResourceDat
 			Target:       []string{data.PrivatelinkAllowedAccountStatuses.ACTIVE.ToString()},
 			Refresh:      PrivatelinkUpdateStateRefreshFunc(client, d.Id()),
 			Timeout:      time.Duration(config.PrivatelinkAllowedAccountsAddTimeout) * time.Minute,
-			PollInterval: 15 * time.Second,
+			PollInterval: StateRefreshPollInterval,
 		}
 
 		if _, err := stateConf.WaitForStateContext(ctx); err != nil {
@@ -234,7 +234,7 @@ func resourceHerokuxPrivatelinkDelete(ctx context.Context, d *schema.ResourceDat
 		Target:       []string{data.PrivatelinkStatuses.DEPROVISIONED.ToString()},
 		Refresh:      PrivatelinkDeleteStateRefreshFunc(client, d.Id()),
 		Timeout:      time.Duration(config.PrivatelinkDeleteTimeout) * time.Minute,
-		PollInterval: 15 * time.Second,
+		PollInterval: StateRefreshPollInterval,
 	}
 
 	if _, err := stateConf.WaitForStateContext(ctx); err != nil {

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -8,15 +8,15 @@ description: |-
 
 # HerokuX Provider
 
-The HerokuX provider interacts with undocumented Heroku APIs to provide additional resources not available
+The HerokuX provider interacts with APIs outside of the Heroku Platform APIs to provide additional resources not available
 in the official [Heroku Terraform provider](https://github.com/heroku/terraform-provider-heroku).
+Most of this provider's resource, if not all, are derived from Heroku CLI and plugin commands and usually require
+Heroku provider resources as a prerequisite.
+
 **This provider has no relationship with Heroku.**
 
-This provider is designed to supplement the [Heroku Terraform provider](https://github.com/heroku/terraform-provider-heroku).
-A majority of this provider's resources often require Heroku provider resources to be created first.
-
 -> **IMPORTANT!**
-This provider should be treated as experimental and to be used with caution when terraforming resources in environments
+This provider should be treated as experimental and to be used with caution when Terraforming resources in environments
 that receive customer traffic. Additionally, the resources may change in behavior at any given time to match any API changes.
 
 ## Contributing
@@ -34,8 +34,8 @@ provider "herokux" {
   # ...
 }
 
-# Create a new project
-resource "herokux_formation_autoscaling" "service-x" {
+# Create a new Kafka topic
+resource "herokux_kafka_topic" "topic_foobar" {
   # ...
 }
 ```
@@ -79,7 +79,7 @@ as the Heroku provider to retrieve the API key. This will be the only common var
 
 ### Netrc
 
-Credentials can instead be sourced from the [`.netrc`](https://ec.haxx.se/usingcurl-netrc.html)
+Credentials can also be sourced from the [`.netrc`](https://ec.haxx.se/usingcurl-netrc.html)
 file in your home directory:
 
 ```hcl
@@ -112,8 +112,9 @@ The following arguments are supported:
 
 * `headers` - (Optional) Additional API headers.
 
-* `timeouts` - (Optional) Timeouts help certain resources to be properly created or deleted before proceeding with further actions.
-Only a single `timeouts` block may be specified and it supports the following arguments:
+* `timeouts` - (Optional) Timeouts define a max duration the provider will wait for certain resources
+to be properly modified before proceeding with further action(s). Each timeout's polling intervals is set to 20 seconds.
+Only a single `timeouts` block may be specified, and it supports the following arguments:
 
   * `mtls_provision_timeout` - (Optional) The number of minutes to wait for a MTLS configuration
   to be provisioned on a database. Defaults to 10 minutes. Minimum required (based off of Heroku documentation) is 5 minutes.


### PR DESCRIPTION
Standardize the polling interval to 20 seconds to alleviate unnecessary calls to the APIs as most resources take time to be provisioned, deprovisioned, or modified.

This can be adjusted later on as needed.