### PR TITLE
New resource: `herokux_postgres_settings`

### DIFF
--- a/api/postgres/postgres-accessors.go
+++ b/api/postgres/postgres-accessors.go
@@ -411,6 +411,142 @@ func (g *GenericResponse) GetMessage() string {
 	return *g.Message
 }
 
+// GetDefault returns the Default field if it's non-nil, zero value otherwise.
+func (l *LogConnections) GetDefault() bool {
+	if l == nil || l.Default == nil {
+		return false
+	}
+	return *l.Default
+}
+
+// GetDescription returns the Description field if it's non-nil, zero value otherwise.
+func (l *LogConnections) GetDescription() string {
+	if l == nil || l.Description == nil {
+		return ""
+	}
+	return *l.Description
+}
+
+// GetValue returns the Value field if it's non-nil, zero value otherwise.
+func (l *LogConnections) GetValue() bool {
+	if l == nil || l.Value == nil {
+		return false
+	}
+	return *l.Value
+}
+
+// GetDefault returns the Default field if it's non-nil, zero value otherwise.
+func (l *LogLockWaits) GetDefault() bool {
+	if l == nil || l.Default == nil {
+		return false
+	}
+	return *l.Default
+}
+
+// GetDescription returns the Description field if it's non-nil, zero value otherwise.
+func (l *LogLockWaits) GetDescription() string {
+	if l == nil || l.Description == nil {
+		return ""
+	}
+	return *l.Description
+}
+
+// GetValue returns the Value field if it's non-nil, zero value otherwise.
+func (l *LogLockWaits) GetValue() bool {
+	if l == nil || l.Value == nil {
+		return false
+	}
+	return *l.Value
+}
+
+// GetDefault returns the Default field if it's non-nil, zero value otherwise.
+func (l *LogMinDurationStatement) GetDefault() int {
+	if l == nil || l.Default == nil {
+		return 0
+	}
+	return *l.Default
+}
+
+// GetDescription returns the Description field if it's non-nil, zero value otherwise.
+func (l *LogMinDurationStatement) GetDescription() string {
+	if l == nil || l.Description == nil {
+		return ""
+	}
+	return *l.Description
+}
+
+// GetValue returns the Value field if it's non-nil, zero value otherwise.
+func (l *LogMinDurationStatement) GetValue() int {
+	if l == nil || l.Value == nil {
+		return 0
+	}
+	return *l.Value
+}
+
+// GetDefault returns the Default field if it's non-nil, zero value otherwise.
+func (l *LogStatement) GetDefault() string {
+	if l == nil || l.Default == nil {
+		return ""
+	}
+	return *l.Default
+}
+
+// GetDescription returns the Description field if it's non-nil, zero value otherwise.
+func (l *LogStatement) GetDescription() string {
+	if l == nil || l.Description == nil {
+		return ""
+	}
+	return *l.Description
+}
+
+// GetValue returns the Value field if it's non-nil, zero value otherwise.
+func (l *LogStatement) GetValue() string {
+	if l == nil || l.Value == nil {
+		return ""
+	}
+	return *l.Value
+}
+
+// GetValues returns the Values field.
+func (l *LogStatement) GetValues() *LogStatementValues {
+	if l == nil {
+		return nil
+	}
+	return l.Values
+}
+
+// GetAll returns the All field if it's non-nil, zero value otherwise.
+func (l *LogStatementValues) GetAll() string {
+	if l == nil || l.All == nil {
+		return ""
+	}
+	return *l.All
+}
+
+// GetDDL returns the DDL field if it's non-nil, zero value otherwise.
+func (l *LogStatementValues) GetDDL() string {
+	if l == nil || l.DDL == nil {
+		return ""
+	}
+	return *l.DDL
+}
+
+// GetMod returns the Mod field if it's non-nil, zero value otherwise.
+func (l *LogStatementValues) GetMod() string {
+	if l == nil || l.Mod == nil {
+		return ""
+	}
+	return *l.Mod
+}
+
+// GetNone returns the None field if it's non-nil, zero value otherwise.
+func (l *LogStatementValues) GetNone() string {
+	if l == nil || l.None == nil {
+		return ""
+	}
+	return *l.None
+}
+
 // GetWindow returns the Window field if it's non-nil, zero value otherwise.
 func (m *MaintenanceWindowResponse) GetWindow() string {
 	if m == nil || m.Window == nil {
@@ -720,4 +856,52 @@ func (p *PrivatelinkRequest) HasAllowedAccounts() bool {
 		return false
 	}
 	return true
+}
+
+// GetLogConnections returns the LogConnections field.
+func (s *Settings) GetLogConnections() *LogConnections {
+	if s == nil {
+		return nil
+	}
+	return s.LogConnections
+}
+
+// GetLogLockWaits returns the LogLockWaits field.
+func (s *Settings) GetLogLockWaits() *LogLockWaits {
+	if s == nil {
+		return nil
+	}
+	return s.LogLockWaits
+}
+
+// GetLogMinDurationStatement returns the LogMinDurationStatement field.
+func (s *Settings) GetLogMinDurationStatement() *LogMinDurationStatement {
+	if s == nil {
+		return nil
+	}
+	return s.LogMinDurationStatement
+}
+
+// GetLogStatement returns the LogStatement field.
+func (s *Settings) GetLogStatement() *LogStatement {
+	if s == nil {
+		return nil
+	}
+	return s.LogStatement
+}
+
+// GetLogConnections returns the LogConnections field if it's non-nil, zero value otherwise.
+func (s *SettingsRequest) GetLogConnections() bool {
+	if s == nil || s.LogConnections == nil {
+		return false
+	}
+	return *s.LogConnections
+}
+
+// GetLogLockWaits returns the LogLockWaits field if it's non-nil, zero value otherwise.
+func (s *SettingsRequest) GetLogLockWaits() bool {
+	if s == nil || s.LogLockWaits == nil {
+		return false
+	}
+	return *s.LogLockWaits
 }

--- a/api/postgres/settings.go
+++ b/api/postgres/settings.go
@@ -1,0 +1,98 @@
+package postgres
+
+import "github.com/davidji99/simpleresty"
+
+// Settings represents the available settings for a Heroku postgres database.
+type Settings struct {
+	LogLockWaits            *LogLockWaits            `json:"log_lock_waits,omitempty"`
+	LogConnections          *LogConnections          `json:"log_connections,omitempty"`
+	LogMinDurationStatement *LogMinDurationStatement `json:"log_min_duration_statement,omitempty"`
+	LogStatement            *LogStatement            `json:"log_statement,omitempty"`
+}
+
+// LogLockWaits enables whether a log message is produced when a deadlock occurs.
+type LogLockWaits struct {
+	Value       *bool   `json:"value,omitempty"`
+	Description *string `json:"desc,omitempty"`
+	Default     *bool   `json:"default"`
+}
+
+// LogConnections enables logging of all attempted connection.
+type LogConnections struct {
+	Value       *bool   `json:"value,omitempty"`
+	Description *string `json:"desc,omitempty"`
+	Default     *bool   `json:"default"`
+}
+
+// LogMinDurationStatement causes the duration of each completed statement to be logged
+// if the statement ran for at least the specified number of milliseconds.
+type LogMinDurationStatement struct {
+	Value       *int    `json:"value,omitempty"`
+	Description *string `json:"desc,omitempty"`
+	Default     *int    `json:"default"`
+}
+
+// LogStatement controls which SQL statements are logged.
+type LogStatement struct {
+	Value       *string             `json:"value,omitempty"`
+	Description *string             `json:"desc,omitempty"`
+	Default     *string             `json:"default"`
+	Values      *LogStatementValues `json:"values,omitempty"`
+}
+
+// LogStatementValues represents the values for the log statement.
+type LogStatementValues struct {
+	None *string `json:"none,omitempty"`
+	DDL  *string `json:"ddl,omitempty"`
+	Mod  *string `json:"mod,omitempty"`
+	All  *string `json:"all,omitempty"`
+}
+
+// SettingsRequest represents a request to update one or more settings on a postgres database.
+type SettingsRequest struct {
+	// LogLockWaits log when a session waits longer than 1 second to acquire a lock.
+	LogLockWaits *bool `json:"log_lock_waits,omitempty"`
+
+	// LogConnections controls whether a log message is produced when a login attempt is made.
+	LogConnections *bool `json:"log_connections,omitempty"`
+
+	// LogMinDurationStatement is the duration of each completed statement will be logged if the statement completes
+	// after the time specified by a value. This value needs to specified as a whole number, in milliseconds.
+	// A value of `0` logs all queries and `-1` disables logging.
+	LogMinDurationStatement int `json:"log_min_duration_statement,omitempty"`
+
+	// LogStatement defines which statements are logged.
+	// Valid values are:
+	// - none: No statements are logged
+	// - ddl: All data definition statements, such as CREATE, ALTER and DROP will be logged
+	// - mod: Includes all statements from ddl as well as data-modifying statements such as INSERT, UPDATE, DELETE, TRUNCATE, COPY
+	// - all: All statements are logged`,
+	LogStatement string `json:"log_statement,omitempty"`
+}
+
+// GetSettings returns all settings for a postgres database.
+func (p *Postgres) GetSettings(nameOrID string) (*Settings, *simpleresty.Response, error) {
+	var result *Settings
+	urlStr := p.http.RequestURL("/postgres/v0/databases/%s/config", nameOrID)
+
+	// Execute the request
+	response, getErr := p.http.Get(urlStr, &result, nil)
+
+	return result, response, getErr
+}
+
+// UpdateSettings updates one or more settings for a postgres database.
+//
+// NOTE: A successful update request does not necessarily mean the update has been fully applied in Heroku.
+// Often times, subsequent requests may return with a 422 status code that indicates the following:
+// "Still applying previous configuration change to this database. Please try again later."
+func (p *Postgres) UpdateSettings(nameOrID string, opts *SettingsRequest) (*Settings, *simpleresty.Response, error) {
+	var result *Settings
+
+	urlStr := p.http.RequestURL("/postgres/v0/databases/%s/config", nameOrID)
+
+	// Execute the request
+	response, updateErr := p.http.Patch(urlStr, &result, opts)
+
+	return result, response, updateErr
+}

--- a/api/postgres/types.go
+++ b/api/postgres/types.go
@@ -147,3 +147,26 @@ var CredentialStates = struct {
 func (s CredentialState) ToString() string {
 	return string(s)
 }
+
+// LogStatementUpdateOption represents the option to update log statement setting.
+type LogStatementUpdateOption string
+
+// LogStatementUpdateOptions represents all options when updating log statements.
+var LogStatementUpdateOptions = struct {
+	// None: No statements are logged.
+	None LogStatementUpdateOption
+
+	// DDL: All data definition statements, such as CREATE, ALTER and DROP will be logged.
+	DDL LogStatementUpdateOption
+
+	// Mod: Includes all statements from ddl as well as data-modifying statements such as INSERT, UPDATE, DELETE, TRUNCATE, COPY.
+	Mod LogStatementUpdateOption
+
+	// All:  statements are logged.
+	All LogStatementUpdateOption
+}{
+	None: "none",
+	DDL:  "ddl",
+	Mod:  "mod",
+	All:  "all",
+}

--- a/herokux/config.go
+++ b/herokux/config.go
@@ -35,6 +35,7 @@ const (
 	DefaultDataConnectorUpdateTimeout              = int64(10)
 	DefaultPostgresCredentialCreateTimeout         = int64(10)
 	DefaultPostgresCredentialDeleteTimeout         = int64(10)
+	DefaultPostgresSettingsModifyDelay             = int64(2)
 )
 
 type Config struct {
@@ -66,6 +67,9 @@ type Config struct {
 	DataConnectorUpdateTimeout              int64
 	PostgresCredentialCreateTimeout         int64
 	PostgresCredentialDeleteTimeout         int64
+
+	// Custom Delays
+	PostgresSettingsModifyDelay int64
 }
 
 func NewConfig() *Config {
@@ -88,6 +92,7 @@ func NewConfig() *Config {
 		DataConnectorUpdateTimeout:              DefaultDataConnectorUpdateTimeout,
 		PostgresCredentialCreateTimeout:         DefaultPostgresCredentialCreateTimeout,
 		PostgresCredentialDeleteTimeout:         DefaultPostgresCredentialDeleteTimeout,
+		PostgresSettingsModifyDelay:             DefaultPostgresSettingsModifyDelay,
 	}
 	return c
 }
@@ -152,81 +157,94 @@ func (c *Config) applySchema(d *schema.ResourceData) (err error) {
 		c.platformURL = vs
 	}
 
-	if v, ok := d.GetOk("timeouts"); ok {
+	if v, ok := d.GetOk("delays"); ok {
 		vL := v.([]interface{})
 		if len(vL) > 1 {
 			return fmt.Errorf("provider configuration error: only 1 delays config is permitted")
 		}
 		for _, v := range vL {
 			delaysConfig := v.(map[string]interface{})
-			if v, ok := delaysConfig["mtls_provision_timeout"].(int); ok {
+			if v, ok := delaysConfig["postgres_settings_modify_delay"].(int); ok {
+				c.PostgresSettingsModifyDelay = int64(v)
+			}
+		}
+	}
+
+	if v, ok := d.GetOk("timeouts"); ok {
+		vL := v.([]interface{})
+		if len(vL) > 1 {
+			return fmt.Errorf("provider configuration error: only 1 timeout config is permitted")
+		}
+		for _, v := range vL {
+			timeoutsConfig := v.(map[string]interface{})
+			if v, ok := timeoutsConfig["mtls_provision_timeout"].(int); ok {
 				c.MTLSProvisionTimeout = int64(v)
 			}
-			if v, ok := delaysConfig["mtls_deprovision_timeout"].(int); ok {
+			if v, ok := timeoutsConfig["mtls_deprovision_timeout"].(int); ok {
 				c.MTLSDeprovisionTimeout = int64(v)
 			}
 
-			if v, ok := delaysConfig["mtls_iprule_create_timeout"].(int); ok {
+			if v, ok := timeoutsConfig["mtls_iprule_create_timeout"].(int); ok {
 				c.MTLSDeprovisionTimeout = int64(v)
 			}
 
-			if v, ok := delaysConfig["mtls_certificate_create_timeout"].(int); ok {
+			if v, ok := timeoutsConfig["mtls_certificate_create_timeout"].(int); ok {
 				c.MTLSCertificateCreateTimeout = int64(v)
 			}
 
-			if v, ok := delaysConfig["mtls_certificate_delete_timeout"].(int); ok {
+			if v, ok := timeoutsConfig["mtls_certificate_delete_timeout"].(int); ok {
 				c.MTLSCertificateDeleteTimeout = int64(v)
 			}
 
-			if v, ok := delaysConfig["kafka_cg_create_timeout"].(int); ok {
+			if v, ok := timeoutsConfig["kafka_cg_create_timeout"].(int); ok {
 				c.KafkaCGCreateTimeout = int64(v)
 			}
 
-			if v, ok := delaysConfig["kafka_cg_delete_timeout"].(int); ok {
+			if v, ok := timeoutsConfig["kafka_cg_delete_timeout"].(int); ok {
 				c.KafkaCGDeleteTimeout = int64(v)
 			}
 
-			if v, ok := delaysConfig["kafka_topic_create_timeout"].(int); ok {
+			if v, ok := timeoutsConfig["kafka_topic_create_timeout"].(int); ok {
 				c.KafkaTopicCreateTimeout = int64(v)
 			}
 
-			if v, ok := delaysConfig["kafka_topic_update_timeout"].(int); ok {
+			if v, ok := timeoutsConfig["kafka_topic_update_timeout"].(int); ok {
 				c.KafkaTopicUpdateTimeout = int64(v)
 			}
 
-			if v, ok := delaysConfig["privatelink_create_timeout"].(int); ok {
+			if v, ok := timeoutsConfig["privatelink_create_timeout"].(int); ok {
 				c.PrivatelinkCreateTimeout = int64(v)
 			}
 
-			if v, ok := delaysConfig["privatelink_delete_timeout"].(int); ok {
+			if v, ok := timeoutsConfig["privatelink_delete_timeout"].(int); ok {
 				c.PrivatelinkDeleteTimeout = int64(v)
 			}
 
-			if v, ok := delaysConfig["privatelink_allowed_acccounts_add_timeout"].(int); ok {
+			if v, ok := timeoutsConfig["privatelink_allowed_acccounts_add_timeout"].(int); ok {
 				c.PrivatelinkAllowedAccountsAddTimeout = int64(v)
 			}
 
-			if v, ok := delaysConfig["privatelink_allowed_acccounts_remove_timeout"].(int); ok {
+			if v, ok := timeoutsConfig["privatelink_allowed_acccounts_remove_timeout"].(int); ok {
 				c.PrivatelinkAllowedAccountsRemoveTimeout = int64(v)
 			}
 
-			if v, ok := delaysConfig["data_connector_create_timeout"].(int); ok {
+			if v, ok := timeoutsConfig["data_connector_create_timeout"].(int); ok {
 				c.DataConnectorCreateTimeout = int64(v)
 			}
 
-			if v, ok := delaysConfig["data_connector_delete_timeout"].(int); ok {
+			if v, ok := timeoutsConfig["data_connector_delete_timeout"].(int); ok {
 				c.DataConnectorDeleteTimeout = int64(v)
 			}
 
-			if v, ok := delaysConfig["data_connector_update_timeout"].(int); ok {
+			if v, ok := timeoutsConfig["data_connector_update_timeout"].(int); ok {
 				c.DataConnectorUpdateTimeout = int64(v)
 			}
 
-			if v, ok := delaysConfig["postgres_credential_create_timeout"].(int); ok {
+			if v, ok := timeoutsConfig["postgres_credential_create_timeout"].(int); ok {
 				c.PostgresCredentialCreateTimeout = int64(v)
 			}
 
-			if v, ok := delaysConfig["postgres_credential_delete_timeout"].(int); ok {
+			if v, ok := timeoutsConfig["postgres_credential_delete_timeout"].(int); ok {
 				c.PostgresCredentialDeleteTimeout = int64(v)
 			}
 		}

--- a/herokux/helpers.go
+++ b/herokux/helpers.go
@@ -68,6 +68,18 @@ func getKakfaID(d *schema.ResourceData) string {
 	return kafkaID
 }
 
+// getPostgresID extracts the postgres ID attribute generically from a HerokuX resource.
+func getPostgresID(d *schema.ResourceData) string {
+	var postgresID string
+	if v, ok := d.GetOk("postgres_id"); ok {
+		vs := v.(string)
+		log.Printf("[DEBUG] postgres_id: %s", vs)
+		postgresID = vs
+	}
+
+	return postgresID
+}
+
 func parseCompositeID(id string, numOfSplits int) ([]string, error) {
 	parts := strings.SplitN(id, ":", numOfSplits)
 

--- a/herokux/import_herokux_postgres_settings_test.go
+++ b/herokux/import_herokux_postgres_settings_test.go
@@ -1,0 +1,32 @@
+package herokux
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"testing"
+)
+
+func TestAccHerokuxPostgresSettings_importBasic(t *testing.T) {
+	postgresID := testAccConfig.GetAddonIDorSkip(t)
+	wait := true
+	connections := true
+	duration := randInt(-1, 1999)
+	statement := "all"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckHerokuxPostgresSettings_basic(postgresID, wait, connections, duration, statement),
+			},
+			{
+				ResourceName:      "herokux_postgres_settings.foobar",
+				ImportStateId:     postgresID,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/herokux/provider.go
+++ b/herokux/provider.go
@@ -196,6 +196,22 @@ func New() *schema.Provider {
 					},
 				},
 			},
+
+			"delays": {
+				Type:     schema.TypeList,
+				MaxItems: 1,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"postgres_settings_modify_delay": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Default:      2,
+							ValidateFunc: validation.IntAtLeast(1),
+						},
+					},
+				},
+			},
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
@@ -212,6 +228,7 @@ func New() *schema.Provider {
 			"herokux_postgres_mtls":               resourceHerokuxPostgresMTLS(),
 			"herokux_postgres_mtls_certificate":   resourceHerokuxPostgresMTLSCertificate(),
 			"herokux_postgres_mtls_iprule":        resourceHerokuxPostgresMTLSIPRule(),
+			"herokux_postgres_settings":           resourceHerokuxPostgresSettings(),
 			"herokux_privatelink":                 resourceHerokuxPrivatelink(),
 
 			//"herokux_postgres":                  resourceHerokuxPostgres(),

--- a/herokux/resource_herokux_postgres_maintenance_window.go
+++ b/herokux/resource_herokux_postgres_maintenance_window.go
@@ -128,7 +128,7 @@ func resourceHerokuxPostgresMaintenanceWindowRead(ctx context.Context, d *schema
 }
 
 func resourceHerokuxPostgresMaintenanceWindowDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	log.Printf("[DEBUG] Not possible to delete a maintenance window. Existing resource will be removed from state")
+	log.Printf("[DEBUG] Not possible to delete a maintenance window. Existing resource will only be removed from state.")
 
 	d.SetId("")
 	return nil

--- a/herokux/resource_herokux_postgres_settings.go
+++ b/herokux/resource_herokux_postgres_settings.go
@@ -1,0 +1,180 @@
+package herokux
+
+import (
+	"context"
+	"fmt"
+	"github.com/davidji99/terraform-provider-herokux/api/postgres"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"log"
+	"time"
+)
+
+func resourceHerokuxPostgresSettings() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceHerokuxPostgresSettingsCreate,
+		ReadContext:   resourceHerokuxPostgresSettingsRead,
+		UpdateContext: resourceHerokuxPostgresSettingsUpdate,
+		DeleteContext: resourceHerokuxPostgresSettingsDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceHerokuxPostgresSettingsImport,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"postgres_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.IsUUID,
+			},
+
+			"log_lock_waits": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+
+			"log_connections": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+
+			"log_min_duration_statement": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.IntAtLeast(-1),
+			},
+
+			"log_statement": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.StringInSlice([]string{"none", "ddl", "mod", "all"}, false),
+			},
+		},
+	}
+}
+
+func resourceHerokuxPostgresSettingsImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	d.SetId(d.Id())
+
+	readErr := resourceHerokuxPostgresSettingsRead(ctx, d, meta)
+	if readErr != nil {
+		return nil, fmt.Errorf("unable to import postgres settings")
+	}
+
+	return []*schema.ResourceData{d}, nil
+}
+
+func resourceHerokuxPostgresSettingsCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*Config)
+	client := config.API
+	opts := &postgres.SettingsRequest{}
+	postgresID := getPostgresID(d)
+
+	if v, ok := d.GetOk("log_lock_waits"); ok {
+		vb := v.(bool)
+		opts.LogLockWaits = &vb
+		log.Printf("[DEBUG] settings log_lock_waits is : %v", opts.LogLockWaits)
+	}
+
+	if v, ok := d.GetOk("log_connections"); ok {
+		vb := v.(bool)
+		opts.LogConnections = &vb
+		log.Printf("[DEBUG] settings log_connections is : %v", opts.LogConnections)
+	}
+
+	if v, ok := d.GetOk("log_min_duration_statement"); ok {
+		opts.LogMinDurationStatement = v.(int)
+		log.Printf("[DEBUG] settings log_min_duration_statement is : %v", opts.LogMinDurationStatement)
+	}
+
+	if v, ok := d.GetOk("log_statement"); ok {
+		opts.LogStatement = v.(string)
+		log.Printf("[DEBUG] settings log_statement is : %v", opts.LogStatement)
+	}
+
+	log.Printf("[DEBUG] Updating postgres settings on %s with %v", postgresID, opts)
+
+	_, _, updateErr := client.Postgres.UpdateSettings(postgresID, opts)
+	if updateErr != nil {
+		return diag.FromErr(updateErr)
+	}
+
+	log.Printf("[DEBUG] Sleeping for %v minute(s) after updating postgres settings on %s", config.PostgresSettingsModifyDelay, postgresID)
+	time.Sleep(time.Duration(config.PostgresSettingsModifyDelay) * time.Minute)
+
+	// Set resource ID to be the postgres ID
+	d.SetId(d.Get("postgres_id").(string))
+
+	return resourceHerokuxPostgresSettingsRead(ctx, d, meta)
+}
+
+func resourceHerokuxPostgresSettingsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*Config).API
+
+	s, _, getErr := client.Postgres.GetSettings(d.Id())
+	if getErr != nil {
+		return diag.FromErr(getErr)
+	}
+
+	d.Set("postgres_id", d.Id())
+	d.Set("log_lock_waits", s.GetLogLockWaits().GetValue())
+	d.Set("log_connections", s.GetLogConnections().GetValue())
+	d.Set("log_min_duration_statement", s.GetLogMinDurationStatement().GetValue())
+	d.Set("log_statement", s.GetLogStatement().GetValue())
+
+	return nil
+}
+
+func resourceHerokuxPostgresSettingsUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*Config)
+	client := config.API
+	opts := &postgres.SettingsRequest{}
+	postgresID := getPostgresID(d)
+
+	if ok := d.HasChange("log_lock_waits"); ok {
+		vb := d.Get("log_lock_waits").(bool)
+		opts.LogLockWaits = &vb
+		log.Printf("[DEBUG] settings log_lock_waits is : %v", opts.LogLockWaits)
+	}
+
+	if ok := d.HasChange("log_connections"); ok {
+		vb := d.Get("log_connections").(bool)
+		opts.LogConnections = &vb
+		log.Printf("[DEBUG] settings log_connections is : %v", opts.LogConnections)
+	}
+
+	if ok := d.HasChange("log_min_duration_statement"); ok {
+		opts.LogMinDurationStatement = d.Get("log_min_duration_statement").(int)
+		log.Printf("[DEBUG] settings log_min_duration_statement is : %v", opts.LogMinDurationStatement)
+	}
+
+	if ok := d.HasChange("log_statement"); ok {
+		opts.LogStatement = d.Get("log_statement").(string)
+		log.Printf("[DEBUG] settings log_statement is : %v", opts.LogStatement)
+	}
+
+	log.Printf("[DEBUG] Updating postgres settings on %s with %v", postgresID, opts)
+
+	_, _, updateErr := client.Postgres.UpdateSettings(postgresID, opts)
+	if updateErr != nil {
+		return diag.FromErr(updateErr)
+	}
+
+	log.Printf("[DEBUG] Sleeping for %v minute(s) after updating postgres settings on %s", config.PostgresSettingsModifyDelay, postgresID)
+	time.Sleep(time.Duration(config.PostgresSettingsModifyDelay) * time.Minute)
+
+	return resourceHerokuxPostgresSettingsRead(ctx, d, meta)
+}
+
+func resourceHerokuxPostgresSettingsDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	log.Printf("[DEBUG] Not possible to delete postgres setting. Existing resource will only be removed from state.")
+
+	d.SetId("")
+	return nil
+}

--- a/herokux/resource_herokux_postgres_settings_test.go
+++ b/herokux/resource_herokux_postgres_settings_test.go
@@ -1,0 +1,51 @@
+package herokux
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"strconv"
+	"testing"
+)
+
+func TestAccHerokuxPostgresSettings_Basic(t *testing.T) {
+	postgresID := testAccConfig.GetAddonIDorSkip(t)
+	wait := false
+	connections := true
+	duration := randInt(-1, 1999)
+	statement := "mod"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckHerokuxPostgresSettings_basic(postgresID, wait, connections, duration, statement),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"herokux_postgres_settings.foobar", "postgres_id", postgresID),
+					resource.TestCheckResourceAttr(
+						"herokux_postgres_settings.foobar", "log_lock_waits", "false"),
+					resource.TestCheckResourceAttr(
+						"herokux_postgres_settings.foobar", "log_connections", "true"),
+					resource.TestCheckResourceAttr(
+						"herokux_postgres_settings.foobar", "log_min_duration_statement", strconv.Itoa(duration)),
+					resource.TestCheckResourceAttr(
+						"herokux_postgres_settings.foobar", "log_statement", statement),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckHerokuxPostgresSettings_basic(postgresID string, logLocksWaits,
+	logConnections bool, logMinDuration int, logStatement string) string {
+	return fmt.Sprintf(`
+resource "herokux_postgres_settings" "foobar" {
+	postgres_id = "%s"
+	log_lock_waits = %v
+	log_connections = %v
+	log_min_duration_statement = %v
+	log_statement = "%s"
+}
+`, postgresID, logLocksWaits, logConnections, logMinDuration, logStatement)
+}

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -111,6 +111,14 @@ The following arguments are supported:
 
 * `headers` - (Optional) Additional API headers.
 
+* `delays` - (Optional) Delays define a given amount of time to wait before or after a resource takes an action.
+This is to address scenarios where an underlying resource API does not report the status of a change
+and subsequent changes require the previous one to be completed first.
+Only a single `delays` block may be specified, and it supports the following arguments:
+
+  * `postgres_settings_modify_delay` - (Optional) The number of minutes to wait for a postgres settings modification to be
+  properly reflected in Heroku. Defaults to 2 minutes. Minimum required is 1 minute.
+
 * `timeouts` - (Optional) Timeouts define a max duration the provider will wait for certain resources
 to be properly modified before proceeding with further action(s). Each timeout's polling intervals is set to 20 seconds.
 Only a single `timeouts` block may be specified, and it supports the following arguments:

--- a/website/docs/r/data_connector.html.markdown
+++ b/website/docs/r/data_connector.html.markdown
@@ -28,9 +28,8 @@ physical or mental health; and information related to the provision or payment o
 
 ### Resource Timeouts
 During creation, modification and deletion, this resource checks the status of the data connector.
-All the aforementioned timeouts can be customized
-via the `timeouts.data_connector_create_timeout`, `timeouts.data_connector_delete_timeout`
-and `timeouts.data_connector_update_timeout` in your `provider` block.
+All the aforementioned timeouts can be customized via the `timeouts.data_connector_create_timeout`, `timeouts.data_connector_delete_timeout`
+and `timeouts.data_connector_update_timeout` attributes in your `provider` block.
 
 For example:
 ```hcl-terraform

--- a/website/docs/r/kafka_consumer_group.html.markdown
+++ b/website/docs/r/kafka_consumer_group.html.markdown
@@ -12,8 +12,8 @@ This resource manages consumer groups in an existing Heroku Kafka instance.
 
 ### Resource Timeouts
 This resource checks the status of the creation or deletion action.
-Both checks' default timeout is 10 minutes, which can be customized
-via the `timeouts.kafka_cg_create_timeout` and `timeouts.kafka_cg_delete_timeout` in your `provider` block.
+Both checks' default timeout is 10 minutes, which can be customized via the
+`timeouts.kafka_cg_create_timeout` and `timeouts.kafka_cg_delete_timeout` attributes in your `provider` block.
 
 For example:
 ```hcl-terraform

--- a/website/docs/r/kafka_topic.html.markdown
+++ b/website/docs/r/kafka_topic.html.markdown
@@ -26,8 +26,8 @@ Please refer to the following documentation when deciding how to configure a top
 
 ### Resource Timeouts
 This resource checks the status of a creation or update action.
-Both checks' default timeout is 10 minutes, which can be customized
-via the `timeouts.kafka_topic_create_timeout` and `timeouts.kafka_topic_update_timeout` in your `provider` block.
+Both checks' default timeout is 10 minutes, which can be customized via the
+`timeouts.kafka_topic_create_timeout` and `timeouts.kafka_topic_update_timeout` attributes in your `provider` block.
 
 For example:
 ```hcl-terraform

--- a/website/docs/r/postgres_credential.html.markdown
+++ b/website/docs/r/postgres_credential.html.markdown
@@ -22,8 +22,8 @@ Please ensure that your state file is properly secured and encrypted at rest.
 
 ### Resource Timeouts
 During creation and deletion, this resource checks the status of the credential. All the aforementioned timeouts
-can be customized via `timeouts.postgres_credential_create_timeout` and
-`timeouts.postgres_credential_delete_timeout` in your `provider` block.
+can be customized via the `timeouts.postgres_credential_create_timeout` and
+`timeouts.postgres_credential_delete_timeout` attributes in your `provider` block.
 
 For example:
 ```hcl-terraform

--- a/website/docs/r/postgres_mtls.html.markdown
+++ b/website/docs/r/postgres_mtls.html.markdown
@@ -19,7 +19,7 @@ Upon successful MTLS provisioning, Heroku provisions a certificate ready for use
 ### Resource Timeouts
 During creation and deletion, this resource checks the status of the MTLS provisioning or deprovisioning.
 Both checks' default timeout is 10 minutes, which can be customized
-via the `timeouts.mtls_provision_timeout` and `timeouts.mtls_deprovision_timeout` in your `provider` block.
+via the `timeouts.mtls_provision_timeout` and `timeouts.mtls_deprovision_timeout` attributes in your `provider` block.
 
 For example:
 ```hcl-terraform

--- a/website/docs/r/postgres_mtls_certificate.html.markdown
+++ b/website/docs/r/postgres_mtls_certificate.html.markdown
@@ -17,8 +17,8 @@ Please ensure that your state file is properly secured and encrypted at rest.
 
 ### Resource Timeouts
 During creation and deletion, this resource checks the status of the MTLS certificate creation or deletion.
-Both checks' default timeout is ~10 minutes, which can be customized via
-the `timeouts.mtls_certificate_create_timeout` and `timeouts.mtls_certificate_delete_timeout` in your `provider` block.
+Both checks' default timeout is ~10 minutes, which can be customized via the `timeouts.mtls_certificate_create_timeout`
+and `timeouts.mtls_certificate_delete_timeout` attributes in your `provider` block.
 
 For example:
 ```hcl-terraform

--- a/website/docs/r/postgres_mtls_iprule.html.markdown
+++ b/website/docs/r/postgres_mtls_iprule.html.markdown
@@ -16,7 +16,8 @@ Please wait a bit before attempting the action. The actual wait time is unknown 
 
 ### Resource Timeouts
 During creation, this resource checks if the newly IP rule's status changes from 'Authorizing' to 'Authorized'.
-This check's default timeout is ~10 minutes, which can be customized via the `timeouts.mtls_iprule_create_timeout` in your `provider` block.
+This check's default timeout is ~10 minutes, which can be customized via the `timeouts.mtls_iprule_create_timeout` attribute
+in your `provider` block.
 
 For example:
 ```hcl-terraform

--- a/website/docs/r/postgres_settings.html.markdown
+++ b/website/docs/r/postgres_settings.html.markdown
@@ -1,0 +1,77 @@
+---
+layout: "herokux"
+page_title: "HerokuX: herokux_postgres_settings"
+sidebar_current: "docs-herokux-resource-postgres-settings"
+description: |-
+  Provides a resource to manage the settings of a postgres database
+---
+
+# herokux\_postgres\_settings
+
+This resource manages the [settings](https://devcenter.heroku.com/articles/heroku-postgres-settings)
+of a Heroku postgres database.
+
+-> **IMPORTANT!**
+It is not possible to delete a postgres database's settings, so the resource will just be removed from state upon deletion.
+
+### Resource Delays
+This resource will wait a given amount of time after modification. This delay is to allow for Heroku to actually reflect
+the changes to the database before the settings can be modified again. Heroku documentation does not provide
+a recommended or estimated wait period, so this provider provides the means for users to configure this wait period.
+It is likely the size of the database affects the length of this delay.
+
+The aforementioned delay can be customized via the `delays.postgres_settings_modify_delay` attribute in your `provider` block.
+The delay value defaults to 2 minutes with a minimum requirement of 1 minute.
+
+For example:
+```hcl-terraform
+provider "herokux" {
+  delays {
+    postgres_settings_modify_delay = 20
+  }
+}
+```
+
+## Example Usage
+
+```hcl-terraform
+resource "herokux_postgres_settings" "foobar" {
+	postgres_id = "SOME_POSTGRES_ID"
+	log_lock_waits = true
+	log_connections = false
+	log_min_duration_statement = 123
+	log_statement = "none"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `postgres_id` - (Required) `<string>` The UUID of a Heroku postgres addon.
+
+* `log_lock_waits` - `<boolean>` Enables logging when a session waits longer than 1 second
+to acquire a lock. This is useful in determining if lock waits are causing poor performance issues.
+
+* `log_connections` - `<boolean>` Enables logging of all attempted connection.
+
+* `log_min_duration_statement` - `<integer>` Causes the duration of each completed statement to be logged
+if the statement ran for at least the specified number of milliseconds. A value of `0` will log everything,
+and a value of `-1` will disable logging.
+
+* `log_statement` - `<string>` Controls which normal SQL statements are logged. This feature is useful
+when hunting a bug that involves complex queries or inspecting queries made by your app or any database user.
+Valid values for log-statement are:
+  - `none`: Stops logging normal queries. Other logs will still be generated such as slow query logs, queries waiting in locks, and syntax errors.
+  - `ddl`: All data definition statements, such as CREATE, ALTER and DROP will be logged.
+  - `mod`: Includes all statements from ddl as well as data-modifying statements such as `INSERT`, `UPDATE`, `DELETE`, `TRUNCATE`, `COPY.`
+  - `all`: All statements are logged.
+
+## Import
+
+Existing postgres settings can be imported using the postgres ID.
+
+For example:
+```shell script
+$ terraform import herokux_postgres_settings.foobar "<POSTGRES_ID>"
+```

--- a/website/docs/r/privatelink.html.markdown
+++ b/website/docs/r/privatelink.html.markdown
@@ -23,7 +23,7 @@ between 5 and 10 minutes to become available.
 During creation and deletion, this resource checks the status of the privatelink provisioning/deprovisioning
 as well as allowlisting AWS account IDs. All the aforementioned timeouts can be customized
 via the `timeouts.privatelink_create_timeout`, `timeouts.privatelink_delete_timeout`
-and `timeouts.privatelink_allowed_acccounts_add_timeout` in your `provider` block.
+and `timeouts.privatelink_allowed_acccounts_add_timeout` attributes in your `provider` block.
 
 For example:
 ```hcl-terraform

--- a/website/herokux.erb
+++ b/website/herokux.erb
@@ -57,6 +57,10 @@
                   <a href="/docs/providers/herokux/r/postgres_mtls_iprule.html">herokux_postgres_mtls_iprule</a>
                 </li>
 
+                <li<%= sidebar_current("docs-herokux-resource-postgres-settings") %>>
+                  <a href="/docs/providers/herokux/r/postgres_settings.html">herokux_postgres_settings</a>
+                </li>
+
                 <li<%= sidebar_current("docs-herokux-resource-privatelink") %>>
                   <a href="/docs/providers/herokux/r/privatelink.html">herokux_privatelink</a>
                 </li>


### PR DESCRIPTION
The `PATCH` endpoint doesn't check if the updates were fully committed as subsequent `PATCH` requests return a `422` with the below error:

```
{
    "id": "unprocessable_entity",
    "message": "Still applying previous configuration change to this database. Please try again later."
}
```

I don't see any way to loop to check if the updates were applied successfully.

- [x] Test updating resources