### PR TITLE
Make Topic.{BytesIn,BytesOut,MessageIn}PerSecond json.Number

### DIFF
--- a/api/gen-accessors.go
+++ b/api/gen-accessors.go
@@ -304,6 +304,10 @@ func (t *templateData) addSelectorExpr(x *ast.SelectorExpr, receiverType, fieldN
 		if xX == "time" && x.Sel.Name == "Duration" {
 			zeroValue = "0"
 		}
+
+		if xX == "json" && x.Sel.Name == "Number" {
+			zeroValue = "\"\""
+		}
 		t.Getters = append(t.Getters, newGetter(receiverType, fieldName, fieldType, zeroValue, false, false))
 	default:
 		logf("addSelectorExpr: xX %q, type %q, field %q: unknown x=%+v; skipping.", xX, receiverType, fieldName, x)

--- a/api/kafka/kafka-accessors.go
+++ b/api/kafka/kafka-accessors.go
@@ -6,6 +6,7 @@
 package kafka
 
 import (
+	"encoding/json"
 	"time"
 )
 
@@ -482,17 +483,17 @@ func (r *Response) GetMessage() string {
 }
 
 // GetBytesInPerSecond returns the BytesInPerSecond field if it's non-nil, zero value otherwise.
-func (t *Topic) GetBytesInPerSecond() int {
+func (t *Topic) GetBytesInPerSecond() json.Number {
 	if t == nil || t.BytesInPerSecond == nil {
-		return 0
+		return ""
 	}
 	return *t.BytesInPerSecond
 }
 
 // GetBytesOutPerSecond returns the BytesOutPerSecond field if it's non-nil, zero value otherwise.
-func (t *Topic) GetBytesOutPerSecond() int {
+func (t *Topic) GetBytesOutPerSecond() json.Number {
 	if t == nil || t.BytesOutPerSecond == nil {
-		return 0
+		return ""
 	}
 	return *t.BytesOutPerSecond
 }
@@ -530,9 +531,9 @@ func (t *Topic) GetDataSize() int {
 }
 
 // GetMessageInPerSecond returns the MessageInPerSecond field if it's non-nil, zero value otherwise.
-func (t *Topic) GetMessageInPerSecond() int {
+func (t *Topic) GetMessageInPerSecond() json.Number {
 	if t == nil || t.MessageInPerSecond == nil {
-		return 0
+		return ""
 	}
 	return *t.MessageInPerSecond
 }

--- a/api/kafka/topics.go
+++ b/api/kafka/topics.go
@@ -1,7 +1,9 @@
 package kafka
 
 import (
+	"encoding/json"
 	"fmt"
+
 	"github.com/davidji99/simpleresty"
 )
 
@@ -15,21 +17,21 @@ type Topics struct {
 
 // Topic represents a single topic.
 type Topic struct {
-	Name               *string `json:"name,omitempty"`
-	Prefix             *string `json:"prefix,omitempty"`
-	MessageInPerSecond *int    `json:"messages_in_per_second,omitempty"`
-	BytesInPerSecond   *int    `json:"bytes_in_per_second,omitempty"`
-	BytesOutPerSecond  *int    `json:"bytes_out_per_second,omitempty"`
-	Partitions         *int    `json:"partitions,omitempty"`
-	ReplicationFactor  *int    `json:"replication_factor,omitempty"`
-	Status             *string `json:"status,omitempty"`
-	StatusLabel        *string `json:"status_label,omitempty"`
-	DataSize           *int    `json:"data_size,omitempty"`
-	Compaction         *bool   `json:"compaction,omitempty"`
-	RetentionTimeInMS  *int    `json:"retention_time_ms,omitempty"`
-	CleanupPolicy      *string `json:"cleanup_policy,omitempty"`
-	CompactionEnabled  *bool   `json:"compaction_enabled,omitempty"`
-	RetentionEnabled   *bool   `json:"retention_enabled,omitempty"`
+	Name               *string      `json:"name,omitempty"`
+	Prefix             *string      `json:"prefix,omitempty"`
+	MessageInPerSecond *json.Number `json:"messages_in_per_second,omitempty"`
+	BytesInPerSecond   *json.Number `json:"bytes_in_per_second,omitempty"`
+	BytesOutPerSecond  *json.Number `json:"bytes_out_per_second,omitempty"`
+	Partitions         *int         `json:"partitions,omitempty"`
+	ReplicationFactor  *int         `json:"replication_factor,omitempty"`
+	Status             *string      `json:"status,omitempty"`
+	StatusLabel        *string      `json:"status_label,omitempty"`
+	DataSize           *int         `json:"data_size,omitempty"`
+	Compaction         *bool        `json:"compaction,omitempty"`
+	RetentionTimeInMS  *int         `json:"retention_time_ms,omitempty"`
+	CleanupPolicy      *string      `json:"cleanup_policy,omitempty"`
+	CompactionEnabled  *bool        `json:"compaction_enabled,omitempty"`
+	RetentionEnabled   *bool        `json:"retention_enabled,omitempty"`
 }
 
 // TopicLimits represents limits on topics.


### PR DESCRIPTION
These fields can sometimes be the integer `0` or string encoded floats
when returned from the Heroku API.

This causes Unmarshalling to fail, using `json.Number` handles these
edge-cases.

Signed-off-by: Christian Gregg <christian@bissy.io>