### PR TITLE
Set kafka_id on resourceHerokuxKafkaTopicRead

### DIFF
--- a/herokux/helpers.go
+++ b/herokux/helpers.go
@@ -2,10 +2,11 @@ package herokux
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"log"
 	"math/rand"
 	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 // getAppId extracts the app ID attribute generically from a HerokuX resource.
@@ -56,8 +57,8 @@ func getDatabaseName(d *schema.ResourceData) string {
 	return dbName
 }
 
-// getKakfaID extracts the kafka/cluster ID attribute generically from a HerokuX resource.
-func getKakfaID(d *schema.ResourceData) string {
+// getKafkaID extracts the kafka/cluster ID attribute generically from a HerokuX resource.
+func getKafkaID(d *schema.ResourceData) string {
 	var kafkaID string
 	if v, ok := d.GetOk("kafka_id"); ok {
 		vs := v.(string)

--- a/herokux/resource_herokux_kafka_consumer_group.go
+++ b/herokux/resource_herokux_kafka_consumer_group.go
@@ -3,14 +3,15 @@ package herokux
 import (
 	"context"
 	"fmt"
+	"log"
+	"time"
+
 	"github.com/davidji99/simpleresty"
 	"github.com/davidji99/terraform-provider-herokux/api/kafka"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"log"
-	"time"
 )
 
 func resourceHerokuxKafkaConsumerGroup() *schema.Resource {
@@ -56,7 +57,7 @@ func resourceHerokuxKafkaConsumerGroupCreate(ctx context.Context, d *schema.Reso
 	client := config.API
 	opts := kafka.NewConsumerGroupRequest()
 
-	kafkaID := getKakfaID(d)
+	kafkaID := getKafkaID(d)
 
 	if v, ok := d.GetOk("name"); ok {
 		opts.Name = v.(string)

--- a/herokux/resource_herokux_kafka_topic.go
+++ b/herokux/resource_herokux_kafka_topic.go
@@ -3,15 +3,16 @@ package herokux
 import (
 	"context"
 	"fmt"
+	"log"
+	"regexp"
+	"time"
+
 	"github.com/davidji99/terraform-provider-herokux/api"
 	"github.com/davidji99/terraform-provider-herokux/api/kafka"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"log"
-	"regexp"
-	"time"
 )
 
 func resourceHerokuxKafkaTopic() *schema.Resource {
@@ -241,6 +242,7 @@ func resourceHerokuxKafkaTopicRead(ctx context.Context, d *schema.ResourceData, 
 		}
 	}
 
+	d.Set("kafka_id", kafkaID)
 	d.Set("name", topic.GetName())
 	d.Set("partitions", topic.GetPartitions())
 	d.Set("replication_factor", topic.GetReplicationFactor())

--- a/herokux/resource_herokux_kafka_topic.go
+++ b/herokux/resource_herokux_kafka_topic.go
@@ -119,7 +119,7 @@ func resourceHerokuxKafkaTopicCreate(ctx context.Context, d *schema.ResourceData
 	client := config.API
 	opts := &kafka.TopicRequest{}
 
-	kafkaID := getKakfaID(d)
+	kafkaID := getKafkaID(d)
 
 	if v, ok := d.GetOk("name"); ok {
 		vs := v.(string)
@@ -259,7 +259,7 @@ func resourceHerokuxKafkaTopicUpdate(ctx context.Context, d *schema.ResourceData
 	client := config.API
 
 	opts := &kafka.TopicRequest{}
-	kafkaID := getKakfaID(d)
+	kafkaID := getKafkaID(d)
 	checkFuncs := make([]func(t *kafka.Topic) bool, 0)
 
 	if v, ok := d.GetOk("name"); ok {


### PR DESCRIPTION
Set `kafka_id` on read so that terraform is aware of its value and
doesn't force recreating the topic.

Because we currently are not setting this value if the tf file contains
a `kafka_id` terraform will try to recreate it because it has changed
from unset->set.

Signed-off-by: Christian Gregg <christian@bissy.io>