### PR TITLE
Implement new resource: `herokux_redis_maintenance_window`

### DIFF
--- a/api/redis/maintenance.go
+++ b/api/redis/maintenance.go
@@ -1,0 +1,49 @@
+package redis
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/davidji99/simpleresty"
+)
+
+// MaintenanceWindowResponse represents the response from the Redis API when setting the maintenance window.
+type MaintenanceWindowResponse struct {
+	Window *string `json:"window,omitempty"`
+}
+
+// GetMaintenanceWindow returns the maintenance window for a redis database.
+//
+// All times are in UTC.
+func (p *Redis) GetMaintenanceWindow(dbID string) (*GenericResponse, *simpleresty.Response, error) {
+	var result *GenericResponse
+	urlStr := p.http.RequestURL("/redis/v0/databases/%s/maintenance", dbID)
+
+	// Execute the request
+	response, getErr := p.http.Get(urlStr, &result, nil)
+
+	return result, response, getErr
+}
+
+// SetMaintenanceWindow sets the the weekly maintenance window for a redis database.
+func (p *Redis) SetMaintenanceWindow(dbID, window string) (*MaintenanceWindowResponse, *simpleresty.Response, error) {
+	var result *MaintenanceWindowResponse
+	urlStr := p.http.RequestURL("/redis/v0/databases/%s/maintenance_window", dbID)
+
+	// Validate the window string
+	regex := regexp.MustCompile(`[A-Za-z]{2,10} \d\d?:[03]0$`)
+	if !regex.MatchString(window) {
+		return nil, nil, fmt.Errorf("window must be \"Day HH:MM\" where MM is 00 or 30")
+	}
+
+	body := struct {
+		Description string `json:"description"`
+	}{
+		Description: window,
+	}
+
+	// Execute the request
+	response, getErr := p.http.Put(urlStr, &result, &body)
+
+	return result, response, getErr
+}

--- a/api/redis/redis-accessors.go
+++ b/api/redis/redis-accessors.go
@@ -148,3 +148,27 @@ func (c *ConfigUpdateRequest) GetTimeout() int {
 	}
 	return *c.Timeout
 }
+
+// GetID returns the ID field if it's non-nil, zero value otherwise.
+func (g *GenericResponse) GetID() string {
+	if g == nil || g.ID == nil {
+		return ""
+	}
+	return *g.ID
+}
+
+// GetMessage returns the Message field if it's non-nil, zero value otherwise.
+func (g *GenericResponse) GetMessage() string {
+	if g == nil || g.Message == nil {
+		return ""
+	}
+	return *g.Message
+}
+
+// GetWindow returns the Window field if it's non-nil, zero value otherwise.
+func (m *MaintenanceWindowResponse) GetWindow() string {
+	if m == nil || m.Window == nil {
+		return ""
+	}
+	return *m.Window
+}

--- a/api/redis/redis.go
+++ b/api/redis/redis.go
@@ -13,9 +13,15 @@ type Redis struct {
 	config *config2.Config
 }
 
+// GenericResponse represents a generic response from the Redis API.
+type GenericResponse struct {
+	ID      *string `json:"id,omitempty"`
+	Message *string `json:"message,omitempty"`
+}
+
 // New constructs a client to interface with the Heroku Redis APIs.
 func New(config *config2.Config) *Redis {
-	r := &Redis{http: simpleresty.NewWithBaseURL(config.PostgresBaseURL), config: config}
+	r := &Redis{http: simpleresty.NewWithBaseURL(config.RedisBaseURL), config: config}
 	r.setHeaders()
 
 	return r

--- a/herokux/provider.go
+++ b/herokux/provider.go
@@ -271,6 +271,7 @@ func New() *schema.Provider {
 			"herokux_postgres_settings":           resourceHerokuxPostgresSettings(),
 			"herokux_privatelink":                 resourceHerokuxPrivatelink(),
 			"herokux_redis_config":                resourceHerokuxRedisConfig(),
+			"herokux_redis_maintenance_window":    resourceHerokuxRedisMaintenanceWindow(),
 			"herokux_shield_private_space":        resourceHerokuxShieldPrivateSpace(),
 
 			//"herokux_postgres":                  resourceHerokuxPostgres(),

--- a/herokux/resource_herokux_redis_maintenance_window.go
+++ b/herokux/resource_herokux_redis_maintenance_window.go
@@ -1,0 +1,135 @@
+package herokux
+
+import (
+	"context"
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"log"
+	"regexp"
+)
+
+func resourceHerokuxRedisMaintenanceWindow() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceHerokuxRedisMaintenanceWindowCreate,
+		ReadContext:   resourceHerokuxRedisMaintenanceWindowRead,
+		UpdateContext: resourceHerokuxRedisMaintenanceWindowUpdate,
+		DeleteContext: resourceHerokuxRedisMaintenanceWindowDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceHerokuxRedisMaintenanceWindowImport,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"redis_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.IsUUID,
+			},
+
+			"window": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validateRedisMaintenanceWindow,
+			},
+		},
+	}
+}
+
+func validateRedisMaintenanceWindow(v interface{}, k string) (ws []string, errors []error) {
+	name := v.(string)
+	if !regexp.MustCompile(`^[A-Za-z]{2,10}s \d\d?:[03]0$`).MatchString(name) {
+		errors = append(errors, fmt.Errorf("maintenance window format should be 'Days HH:MM' where where MM is 00 or 30"))
+	}
+
+	return
+}
+
+func resourceHerokuxRedisMaintenanceWindowImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	d.SetId(d.Id())
+
+	readErr := resourceHerokuxRedisMaintenanceWindowRead(ctx, d, meta)
+	if readErr != nil {
+		return nil, fmt.Errorf("unable to import maintenance window")
+	}
+
+	return []*schema.ResourceData{d}, nil
+}
+
+func resourceHerokuxRedisMaintenanceWindowCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	modifyErr := setRedisMaintenanceWindow(ctx, d, meta)
+	if modifyErr != nil {
+		return modifyErr
+	}
+
+	d.SetId(d.Get("redis_id").(string))
+
+	return resourceHerokuxRedisMaintenanceWindowRead(ctx, d, meta)
+}
+
+func resourceHerokuxRedisMaintenanceWindowUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	modifyErr := setRedisMaintenanceWindow(ctx, d, meta)
+	if modifyErr != nil {
+		return modifyErr
+	}
+
+	return resourceHerokuxRedisMaintenanceWindowRead(ctx, d, meta)
+}
+
+func setRedisMaintenanceWindow(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*Config).API
+
+	var redisID, window string
+	if v, ok := d.GetOk("window"); ok {
+		window = v.(string)
+		log.Printf("[DEBUG] maintenance window is : %v", window)
+	}
+
+	if v, ok := d.GetOk("redis_id"); ok {
+		redisID = v.(string)
+		log.Printf("[DEBUG] maintenance redis_id is : %v", redisID)
+	}
+
+	log.Printf("[DEBUG] Setting redis maintenance window on %s", redisID)
+
+	_, _, setErr := client.Redis.SetMaintenanceWindow(redisID, window)
+	if setErr != nil {
+		return diag.FromErr(setErr)
+	}
+
+	return nil
+}
+
+func resourceHerokuxRedisMaintenanceWindowRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*Config).API
+
+	w, _, getErr := client.Redis.GetMaintenanceWindow(d.Id())
+	if getErr != nil {
+		return diag.FromErr(getErr)
+	}
+
+	d.Set("redis_id", d.Id())
+
+	// Extract the window from the string returned by the API endpoint.
+	regex := regexp.MustCompile(`^Maintenance.*, window is ([A-Za-z]{2,10} \d\d?:[03]0) to.*$`)
+
+	// If the regex finds a group match, `result` should be an array with a length of two:
+	// - ["Maintenance not required, window is Tuesdays 10:30 to 14:30 UTC", "Tuesdays 10:30"]
+	result := regex.FindStringSubmatch(w.GetMessage())
+	if len(result) == 0 {
+		return diag.Errorf("Could not properly extract the maintenance window time frame. This is likely a provider bug.")
+	}
+
+	d.Set("window", result[1])
+
+	return nil
+}
+
+func resourceHerokuxRedisMaintenanceWindowDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	log.Printf("[DEBUG] Not possible to delete a maintenance window. Existing resource will only be removed from state.")
+
+	d.SetId("")
+	return nil
+}

--- a/herokux/resource_herokux_redis_maintenance_window_test.go
+++ b/herokux/resource_herokux_redis_maintenance_window_test.go
@@ -1,0 +1,39 @@
+package herokux
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestAccHerokuxRedisMaintenanceWindow_Basic(t *testing.T) {
+	redisID := testAccConfig.GetRedisIDorSkip(t)
+	window := fmt.Sprintf("%ss 10:30", strings.Title(time.Weekday(randInt(0, 6)).String()))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckHerokuxRedisMaintenanceWindow_basic(redisID, window),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"herokux_redis_maintenance_window.foobar", "redis_id", redisID),
+					resource.TestCheckResourceAttr(
+						"herokux_redis_maintenance_window.foobar", "window", window),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckHerokuxRedisMaintenanceWindow_basic(redisID, window string) string {
+	return fmt.Sprintf(`
+resource "herokux_redis_maintenance_window" "foobar" {
+	redis_id = "%s"
+	window = "%s"
+}
+`, redisID, window)
+}


### PR DESCRIPTION
Implementing new resource `herokux_redis_maintenance_window` that would add the ability to set the maintenance window for Redis add-ons.

Resolves #64 