### PR TITLE
Fix timezone validation in herokux_postgres_backup_schedule

### DIFF
--- a/herokux/resource_herokux_postgres_backup_schedule.go
+++ b/herokux/resource_herokux_postgres_backup_schedule.go
@@ -64,7 +64,7 @@ func resourceHerokuxPostgresBackupSchedule() *schema.Resource {
 
 func validateBackupScheduleTimezone(v interface{}, k string) (ws []string, errors []error) {
 	timezone := v.(string)
-	if !regexp.MustCompile(`^UTC|[a-zA-Z]+/[a-zA-Z]+$`).MatchString(timezone) {
+	if !regexp.MustCompile(`^UTC|[a-zA-Z]+/[a-zA-Z_]+$`).MatchString(timezone) {
 		errors = append(errors, fmt.Errorf("Invalid timezone format. Timezone should be in full TZ format (Africa/Cairo) or UTC."))
 	}
 	return


### PR DESCRIPTION
Updating the regular expression that validates the `timezone` in `herokux_postgres_backup_schedule` so it accepts underscores.

Resolves #74 