### PR TITLE
Yet another fix/improvement to `herokux_formation_autoscaling`

### DIFF
--- a/api/metrics/formation.go
+++ b/api/metrics/formation.go
@@ -7,6 +7,7 @@ import (
 )
 
 const (
+	// AutoscalingOperationAttrVal defines the only possible value for `op` or operation.
 	AutoscalingOperationAttrVal = "GREATER_OR_EQUAL"
 )
 

--- a/api/metrics/formation.go
+++ b/api/metrics/formation.go
@@ -6,6 +6,10 @@ import (
 	"github.com/davidji99/simpleresty"
 )
 
+const (
+	AutoscalingOperationAttrVal = "GREATER_OR_EQUAL"
+)
+
 // FormationMonitor represents a formation monitor.
 type FormationMonitor struct {
 	ID                   *string                     `json:"id,omitempty"`

--- a/docs/resources/formation_autoscaling.md
+++ b/docs/resources/formation_autoscaling.md
@@ -26,7 +26,7 @@ if you are using dyno sizes that can be autoscaled and wish to do so. Otherwise,
 
 Users will need to add the [`depends_on`](https://www.terraform.io/docs/language/meta-arguments/depends_on.html) meta-argument
 to `herokux_formation_autoscaling` when `heroku_app_release` and/or `heroku_formation` are present. `heroku_formation`
-does not need to be in `herokux_formation_autoscaling.depends_on` if `herokux_formation_autoscaling.formation_name` is set
+does not need to be in `herokux_formation_autoscaling.depends_on` if `herokux_formation_autoscaling.process_type` is set
 to `heroku_formation.foobar.type`.
 
 See the example [resource configuration](#example-usage) below on how to use `heroku_formation` with `herokux_formation_autoscaling`.
@@ -95,7 +95,7 @@ resource "heroku_formation" "foobar" {
 
 resource "herokux_formation_autoscaling" "foobar" {
   app_id = heroku_app.foobar.uuid
-  formation_name = heroku_formation.foobar.type
+  process_type = heroku_formation.foobar.type
   is_active = true
   min_quantity = 7
   max_quantity = 9
@@ -115,7 +115,7 @@ The following arguments are supported:
 
 * `app_id` - (Required) `<string>` An existing app's UUID. The app name is not valid for this argument.
 
-* `formation_name` - (Required) `<string>` The name of the dyno formation process, such as `web`.
+* `process_type` - (Required) `<string>` The type of the dyno formation process, such as `web`.
 
 * `is_active` - (Required) `<boolean>` Whether to enable or disable the autoscaling.
 

--- a/docs/resources/formation_autoscaling.md
+++ b/docs/resources/formation_autoscaling.md
@@ -9,25 +9,33 @@ description: |-
 # herokux\_formation\_autoscaling
 
 This resource manages the autoscaling settings of an app dyno formation.
-For more information about Heroku dyno formation scaling, please visit this [help article](https://devcenter.heroku.com/articles/scaling#autoscaling).
-
-This resource can replace  [`heroku_formation`](https://registry.terraform.io/providers/heroku/heroku/latest/docs/resources/formation).
-It is recommended NOT TO USE both resources concurrently. Furthermore like `heroku_formation`, users will need
-to add the [`depends_on`](https://www.terraform.io/docs/language/meta-arguments/depends_on.html) meta-argument
-to `herokux_formation_autoscaling` when `heroku_app_release` is present. See the example [resource configuration](#example-usage) below.
+For more information about Heroku dyno formation autoscaling, please visit this [help article](https://devcenter.heroku.com/articles/scaling#autoscaling).
 
 -> **IMPORTANT!**
-Due to API limitations, the provider will only remove the resource from state if you remove an existing
-`herokux_formation_autoscaling` from your terraform configuration. You will then need to visit the Heroku UI for further action.
+When an existing `herokux_formation_autoscaling` is deleted, the provider will disable the autoscaling remotely
+and remove the resource from state.
 
 ~> **WARNING:**
 Please make sure you understand all [common issues](#common-issues) prior to using this resource. Failure to understand
 them will result in potentially bricking your app dynos. You have been warned!
 
+## Regarding `heroku_formation`
+
+This resource can replace [`heroku_formation`](https://registry.terraform.io/providers/heroku/heroku/latest/docs/resources/formation)
+if you are using dynos that can be autoscaled and wish to do so. Otherwise, continue using `heroku_formation`.
+It is recommended NOT TO USE both resources concurrently.
+
+Like `heroku_formation`, users will need to add the
+[`depends_on`](https://www.terraform.io/docs/language/meta-arguments/depends_on.html) meta-argument
+to `herokux_formation_autoscaling` when `heroku_app_release` is present. See the example [resource configuration](#example-usage) below.
+
 ## Common Issues
 
 1. If you receive a `403` error during a `terraform apply`, it is likely you are trying to setup autoscaling
 on an unsupported dyno type. Autoscaling is currently available only for Performance-tier dynos and dynos running in Private Spaces.
+
+1. If you are migrating from using `heroku_formation` to `herokux_formation_autoscaling`, you can simply replace the former
+with the latter ONLY IF the app dyno has never been autoscaled previously. Otherwise, follow the guidance below.
 
 1. In the event you remove an existing `herokux_formation_autoscaling.foobar` resource after it's been successfully applied to an app,
    you will HAVE to `import` the resource first if the new `herokux_formation_autoscaling.foobar` resource is targeting
@@ -39,8 +47,8 @@ on an unsupported dyno type. Autoscaling is currently available only for Perform
     * Due to the first reason, the underlying API does not allow for a `POST` request when an existing formation autoscaling
       exists in the API. Therefore, the resource must be imported first and then modified afterwards.
 
-1. In the event you fail to comply with the aforementioned issue's directive, the only solution is to delete the app
-start over.
+1. In the event you fail to comply with the aforementioned issue's guidance, the only solution is to delete the app
+and start over.
 
 ## Example Usage
 

--- a/docs/resources/formation_autoscaling.md
+++ b/docs/resources/formation_autoscaling.md
@@ -125,9 +125,7 @@ The following arguments are supported:
 
 * `desired_p95_response_time` - (Required) `<integer>` Desired P95 Response Time in milliseconds. Must be at least 1ms.
 
-* `dyno_size` - (Optional) `<string>` The size of dyno. (Example: “standard-1X”). Capitalization does not matter.
-    - Use with caution if you already defined the dyno type in a `heroku_formation.size` resource attribute.
-    Defining different values can lead to an infinite `plan` delta.
+* `dyno_size` - (Required) `<string>` The size of dyno. (Example: “standard-1X”). Capitalization does not matter.
 
 * `notification_channels` - (Optional) `<list(string)>` Channels you want to be notified if autoscaling occurs
 for a dyno formation. The only currently valid value is `["app"]` or `[]`, which will turn on email notifications.

--- a/docs/resources/formation_autoscaling.md
+++ b/docs/resources/formation_autoscaling.md
@@ -21,8 +21,10 @@ them will result in potentially bricking your app dynos. You have been warned!
 
 ## Regarding `heroku_formation`
 
-This resource should be used with [`heroku_formation`](https://registry.terraform.io/providers/heroku/heroku/latest/docs/resources/formation)
+This resource can be used with [`heroku_formation`](https://registry.terraform.io/providers/heroku/heroku/latest/docs/resources/formation)
 if you are using dyno sizes that can be autoscaled and wish to do so. Otherwise, continue using just `heroku_formation`.
+If you end up using `heroku_formation` in conjunction with `herokux_formation_autoscaling`, do not make any changes to
+`heroku_formation` as those changes will not be reflected on the app dyno if autoscaling is enabled.
 
 Users will need to add the [`depends_on`](https://www.terraform.io/docs/language/meta-arguments/depends_on.html) meta-argument
 to `herokux_formation_autoscaling` when `heroku_app_release` and/or `heroku_formation` are present. `heroku_formation`
@@ -125,7 +127,8 @@ The following arguments are supported:
 
 * `desired_p95_response_time` - (Required) `<integer>` Desired P95 Response Time in milliseconds. Must be at least 1ms.
 
-* `dyno_size` - (Required) `<string>` The size of dyno. (Example: “standard-1X”). Capitalization does not matter.
+* `dyno_size` - (Required) `<string>` The size of dyno. (Example: “performance-l”). Capitalization does not matter.
+Only specify dyno sizes that can be autoscaled.
 
 * `notification_channels` - (Optional) `<list(string)>` Channels you want to be notified if autoscaling occurs
 for a dyno formation. The only currently valid value is `["app"]` or `[]`, which will turn on email notifications.

--- a/herokux/helpers.go
+++ b/herokux/helpers.go
@@ -34,16 +34,16 @@ func getAddonID(d *schema.ResourceData) string {
 	return addonID
 }
 
-// getFormationName extracts the formation name attribute generically from a HerokuX resource.
-func getFormationName(d *schema.ResourceData) string {
-	var formationName string
-	if v, ok := d.GetOk("formation_name"); ok {
+// getProcessType extracts the process type attribute generically from a HerokuX resource.
+func getProcessType(d *schema.ResourceData) string {
+	var processType string
+	if v, ok := d.GetOk("process_type"); ok {
 		vs := v.(string)
-		log.Printf("[DEBUG] formation_name: %s", vs)
-		formationName = vs
+		log.Printf("[DEBUG] process_type: %s", vs)
+		processType = vs
 	}
 
-	return formationName
+	return processType
 }
 
 // getDatabaseName extracts the database name name attribute generically from a HerokuX resource.

--- a/herokux/import_herokux_formation_autoscaling_test.go
+++ b/herokux/import_herokux_formation_autoscaling_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestAccHerokuxFormationAutoscaling_importBasic(t *testing.T) {
 	appID := testAccConfig.GetAppIDorSkip(t)
-	formationName := "web"
+	processType := "web"
 	minQuantity := acctest.RandIntRange(1, 8)
 	maxQuantity := minQuantity + 2
 	p95ResponseTime := acctest.RandIntRange(500, 1000)
@@ -21,11 +21,11 @@ func TestAccHerokuxFormationAutoscaling_importBasic(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckHerokuxFormationAutoscaling_basic(appID, formationName, minQuantity, maxQuantity, p95ResponseTime),
+				Config: testAccCheckHerokuxFormationAutoscaling_basic(appID, processType, minQuantity, maxQuantity, p95ResponseTime),
 			},
 			{
 				ResourceName:      "herokux_formation_autoscaling.foobar",
-				ImportStateId:     fmt.Sprintf("%s:%s", appID, formationName),
+				ImportStateId:     fmt.Sprintf("%s:%s", appID, processType),
 				ImportState:       true,
 				ImportStateVerify: true,
 			},

--- a/herokux/provider.go
+++ b/herokux/provider.go
@@ -254,6 +254,7 @@ func New() *schema.Provider {
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
+			//"herokux_app_alert":                   resourceHerokuxAppAlert(),
 			"herokux_app_container_release":       resourceHerokuxAppContainerRelease(),
 			"herokux_app_webhook":                 resourceHerokuxAppWebhook(),
 			"herokux_connect_mappings":            resourceHerokuxConnectMappings(),

--- a/herokux/resource_herokux_app_alert.go
+++ b/herokux/resource_herokux_app_alert.go
@@ -1,0 +1,68 @@
+package herokux
+
+import (
+	"context"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"time"
+)
+
+func resourceHerokuxAppAlert() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceHerokuxAppAlertCreate,
+		ReadContext:   resourceHerokuxAppAlertRead,
+		UpdateContext: resourceHerokuxAppAlertUpdate,
+		DeleteContext: resourceHerokuxAppAlertDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceHerokuxAppAlertImport,
+		},
+
+		// https://www.terraform.io/docs/extend/resources/retries-and-customizable-timeouts.html
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"app_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.IsUUID,
+			},
+
+			"process_type": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"image_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validateImageID,
+			},
+		},
+	}
+}
+
+func resourceHerokuxAppAlertImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	return []*schema.ResourceData{d}, nil
+}
+
+func resourceHerokuxAppAlertCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return resourceHerokuxAppAlertRead(ctx, d, meta)
+}
+
+func resourceHerokuxAppAlertRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceHerokuxAppAlertUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return resourceHerokuxAppAlertRead(ctx, d, meta)
+}
+
+func resourceHerokuxAppAlertDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return nil
+}

--- a/herokux/resource_herokux_formation_autoscaling.go
+++ b/herokux/resource_herokux_formation_autoscaling.go
@@ -414,10 +414,12 @@ func formatSize(quant interface{}) string {
 	}
 
 	var rawQuant string
-	switch quant.(type) {
+	switch t := quant.(type) {
 	case string:
+		log.Printf("[DEBUG] quant %v", t)
 		rawQuant = quant.(string)
 	case *string:
+		log.Printf("[DEBUG] quant %v", t)
 		rawQuant = *quant.(*string)
 	default:
 		return ""

--- a/herokux/resource_herokux_formation_autoscaling.go
+++ b/herokux/resource_herokux_formation_autoscaling.go
@@ -65,8 +65,7 @@ func resourceHerokuxFormationAutoscaling() *schema.Resource {
 
 			"dyno_size": {
 				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
+				Required:     true,
 				ValidateFunc: validation.StringInSlice(ValidDynoTypesForAutoscaling, true),
 			},
 

--- a/herokux/resource_herokux_formation_autoscaling.go
+++ b/herokux/resource_herokux_formation_autoscaling.go
@@ -303,14 +303,15 @@ func resourceHerokuxFormationAutoscalingDelete(ctx context.Context, d *schema.Re
 	if formationGetErr != nil {
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
-			Summary:  fmt.Sprintf("unable to retrieve formation %s information", processType),
+			Summary:  fmt.Sprintf("unable to retrieve formation %s information prior to resource deletion", processType),
 			Detail:   formationGetErr.Error(),
 		})
 		return diags
 	}
 
 	// In order to disable the autoscaling, we'll need to first retrieve the current details of the autoscaling.
-	// Then, create a new request to update the autoscaling with the current information sans is_active = false.
+	// Then, create a new request to update the autoscaling with the current information but is_active set to `false`.
+	// This is the only way to safely, programmatically disable autoscaling like how the UI does it.
 	opts := &metrics.AutoscalingRequest{
 		DynoSize:             formation.Size,
 		IsActive:             false,

--- a/herokux/resource_herokux_formation_autoscaling.go
+++ b/herokux/resource_herokux_formation_autoscaling.go
@@ -63,7 +63,7 @@ func resourceHerokuxFormationAutoscaling() *schema.Resource {
 				Required:     true,
 			},
 
-			"dyno_type": {
+			"dyno_size": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Computed:     true,
@@ -338,9 +338,9 @@ func constructAutoscalingOpts(d *schema.ResourceData) *metrics.AutoscalingReques
 		opts.IsActive = vs
 	}
 
-	if v, ok := d.GetOk("dyno_type"); ok {
+	if v, ok := d.GetOk("dyno_size"); ok {
 		vs := v.(string)
-		log.Printf("[DEBUG] dyno_type is : %s", vs)
+		log.Printf("[DEBUG] dyno_size is : %s", vs)
 		opts.DynoSize = vs
 	}
 

--- a/herokux/resource_herokux_formation_autoscaling_test.go
+++ b/herokux/resource_herokux_formation_autoscaling_test.go
@@ -41,6 +41,29 @@ func TestAccHerokuxFormationAutoscaling_Basic(t *testing.T) {
 						"herokux_formation_autoscaling.foobar", "period", "1"),
 				),
 			},
+			{
+				Config: testAccCheckHerokuxFormationAutoscaling_basicNoNotifications(appID, formationName, minQuantity+1, maxQuantity, p95ResponseTime),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"herokux_formation_autoscaling.foobar", "app_id", appID),
+					resource.TestCheckResourceAttr(
+						"herokux_formation_autoscaling.foobar", "formation_name", formationName),
+					resource.TestCheckResourceAttr(
+						"herokux_formation_autoscaling.foobar", "is_active", "true"),
+					resource.TestCheckResourceAttr(
+						"herokux_formation_autoscaling.foobar", "min_quantity", fmt.Sprintf("%d", minQuantity+1)),
+					resource.TestCheckResourceAttr(
+						"herokux_formation_autoscaling.foobar", "max_quantity", fmt.Sprintf("%d", maxQuantity)),
+					resource.TestCheckResourceAttr(
+						"herokux_formation_autoscaling.foobar", "desired_p95_response_time", fmt.Sprintf("%d", p95ResponseTime)),
+					resource.TestCheckResourceAttr(
+						"herokux_formation_autoscaling.foobar", "dyno_type", "performance-l"),
+					resource.TestCheckResourceAttr(
+						"herokux_formation_autoscaling.foobar", "notification_channels.#", "0"),
+					resource.TestCheckResourceAttr(
+						"herokux_formation_autoscaling.foobar", "period", "1"),
+				),
+			},
 		},
 	})
 }
@@ -56,6 +79,21 @@ resource "herokux_formation_autoscaling" "foobar" {
 	desired_p95_response_time = %d
 	dyno_type = "performance-l"
 	notification_channels = ["app"]
+}
+`, appID, formationName, min, max, p95)
+}
+
+func testAccCheckHerokuxFormationAutoscaling_basicNoNotifications(appID, formationName string, min, max, p95 int) string {
+	return fmt.Sprintf(`
+resource "herokux_formation_autoscaling" "foobar" {
+	app_id = "%s"
+	formation_name = "%s"
+	is_active = true
+	min_quantity = %d
+	max_quantity = %d
+	desired_p95_response_time = %d
+	dyno_type = "performance-l"
+	notification_channels = []
 }
 `, appID, formationName, min, max, p95)
 }

--- a/herokux/resource_herokux_formation_autoscaling_test.go
+++ b/herokux/resource_herokux_formation_autoscaling_test.go
@@ -10,7 +10,7 @@ import (
 // IMPORTANT: this test only works on an APP that wasn't autoscaled previously.
 func TestAccHerokuxFormationAutoscaling_Basic(t *testing.T) {
 	appID := testAccConfig.GetAppIDorSkip(t)
-	formationName := "web"
+	processType := "web"
 	minQuantity := acctest.RandIntRange(1, 8)
 	maxQuantity := minQuantity + 2
 	p95ResponseTime := acctest.RandIntRange(500, 1000)
@@ -20,12 +20,12 @@ func TestAccHerokuxFormationAutoscaling_Basic(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckHerokuxFormationAutoscaling_basic(appID, formationName, minQuantity, maxQuantity, p95ResponseTime),
+				Config: testAccCheckHerokuxFormationAutoscaling_basic(appID, processType, minQuantity, maxQuantity, p95ResponseTime),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
 						"herokux_formation_autoscaling.foobar", "app_id", appID),
 					resource.TestCheckResourceAttr(
-						"herokux_formation_autoscaling.foobar", "formation_name", formationName),
+						"herokux_formation_autoscaling.foobar", "process_type", processType),
 					resource.TestCheckResourceAttr(
 						"herokux_formation_autoscaling.foobar", "is_active", "true"),
 					resource.TestCheckResourceAttr(
@@ -43,12 +43,12 @@ func TestAccHerokuxFormationAutoscaling_Basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckHerokuxFormationAutoscaling_basicNoNotifications(appID, formationName, minQuantity+1, maxQuantity, p95ResponseTime),
+				Config: testAccCheckHerokuxFormationAutoscaling_basicNoNotifications(appID, processType, minQuantity+1, maxQuantity, p95ResponseTime),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
 						"herokux_formation_autoscaling.foobar", "app_id", appID),
 					resource.TestCheckResourceAttr(
-						"herokux_formation_autoscaling.foobar", "formation_name", formationName),
+						"herokux_formation_autoscaling.foobar", "process_type", processType),
 					resource.TestCheckResourceAttr(
 						"herokux_formation_autoscaling.foobar", "is_active", "true"),
 					resource.TestCheckResourceAttr(
@@ -69,11 +69,11 @@ func TestAccHerokuxFormationAutoscaling_Basic(t *testing.T) {
 	})
 }
 
-func testAccCheckHerokuxFormationAutoscaling_basic(appID, formationName string, min, max, p95 int) string {
+func testAccCheckHerokuxFormationAutoscaling_basic(appID, processType string, min, max, p95 int) string {
 	return fmt.Sprintf(`
 resource "herokux_formation_autoscaling" "foobar" {
 	app_id = "%s"
-	formation_name = "%s"
+	process_type = "%s"
 	is_active = true
 	min_quantity = %d
 	max_quantity = %d
@@ -81,14 +81,14 @@ resource "herokux_formation_autoscaling" "foobar" {
 	dyno_size = "performance-l"
 	notification_channels = ["app"]
 }
-`, appID, formationName, min, max, p95)
+`, appID, processType, min, max, p95)
 }
 
-func testAccCheckHerokuxFormationAutoscaling_basicNoNotifications(appID, formationName string, min, max, p95 int) string {
+func testAccCheckHerokuxFormationAutoscaling_basicNoNotifications(appID, processType string, min, max, p95 int) string {
 	return fmt.Sprintf(`
 resource "herokux_formation_autoscaling" "foobar" {
 	app_id = "%s"
-	formation_name = "%s"
+	process_type = "%s"
 	is_active = true
 	min_quantity = %d
 	max_quantity = %d
@@ -96,5 +96,5 @@ resource "herokux_formation_autoscaling" "foobar" {
 	dyno_size = "performance-l"
 	notification_channels = []
 }
-`, appID, formationName, min, max, p95)
+`, appID, processType, min, max, p95)
 }

--- a/herokux/resource_herokux_formation_autoscaling_test.go
+++ b/herokux/resource_herokux_formation_autoscaling_test.go
@@ -35,7 +35,7 @@ func TestAccHerokuxFormationAutoscaling_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"herokux_formation_autoscaling.foobar", "desired_p95_response_time", fmt.Sprintf("%d", p95ResponseTime)),
 					resource.TestCheckResourceAttr(
-						"herokux_formation_autoscaling.foobar", "dyno_size", "performance-l"),
+						"herokux_formation_autoscaling.foobar", "dyno_size", "Performance-L"),
 					resource.TestCheckResourceAttr(
 						"herokux_formation_autoscaling.foobar", "notification_channels.0", "app"),
 					resource.TestCheckResourceAttr(
@@ -58,7 +58,7 @@ func TestAccHerokuxFormationAutoscaling_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"herokux_formation_autoscaling.foobar", "desired_p95_response_time", fmt.Sprintf("%d", p95ResponseTime)),
 					resource.TestCheckResourceAttr(
-						"herokux_formation_autoscaling.foobar", "dyno_size", "performance-l"),
+						"herokux_formation_autoscaling.foobar", "dyno_size", "Performance-L"),
 					resource.TestCheckResourceAttr(
 						"herokux_formation_autoscaling.foobar", "notification_channels.#", "0"),
 					resource.TestCheckResourceAttr(

--- a/herokux/resource_herokux_formation_autoscaling_test.go
+++ b/herokux/resource_herokux_formation_autoscaling_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 )
 
+// IMPORTANT: this test only works on an APP that wasn't autoscaled previously.
 func TestAccHerokuxFormationAutoscaling_Basic(t *testing.T) {
 	appID := testAccConfig.GetAppIDorSkip(t)
 	formationName := "web"

--- a/herokux/resource_herokux_formation_autoscaling_test.go
+++ b/herokux/resource_herokux_formation_autoscaling_test.go
@@ -35,7 +35,7 @@ func TestAccHerokuxFormationAutoscaling_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"herokux_formation_autoscaling.foobar", "desired_p95_response_time", fmt.Sprintf("%d", p95ResponseTime)),
 					resource.TestCheckResourceAttr(
-						"herokux_formation_autoscaling.foobar", "dyno_type", "performance-l"),
+						"herokux_formation_autoscaling.foobar", "dyno_size", "performance-l"),
 					resource.TestCheckResourceAttr(
 						"herokux_formation_autoscaling.foobar", "notification_channels.0", "app"),
 					resource.TestCheckResourceAttr(
@@ -58,7 +58,7 @@ func TestAccHerokuxFormationAutoscaling_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"herokux_formation_autoscaling.foobar", "desired_p95_response_time", fmt.Sprintf("%d", p95ResponseTime)),
 					resource.TestCheckResourceAttr(
-						"herokux_formation_autoscaling.foobar", "dyno_type", "performance-l"),
+						"herokux_formation_autoscaling.foobar", "dyno_size", "performance-l"),
 					resource.TestCheckResourceAttr(
 						"herokux_formation_autoscaling.foobar", "notification_channels.#", "0"),
 					resource.TestCheckResourceAttr(
@@ -78,7 +78,7 @@ resource "herokux_formation_autoscaling" "foobar" {
 	min_quantity = %d
 	max_quantity = %d
 	desired_p95_response_time = %d
-	dyno_type = "performance-l"
+	dyno_size = "performance-l"
 	notification_channels = ["app"]
 }
 `, appID, formationName, min, max, p95)
@@ -93,7 +93,7 @@ resource "herokux_formation_autoscaling" "foobar" {
 	min_quantity = %d
 	max_quantity = %d
 	desired_p95_response_time = %d
-	dyno_type = "performance-l"
+	dyno_size = "performance-l"
 	notification_channels = []
 }
 `, appID, formationName, min, max, p95)


### PR DESCRIPTION
## Breaking changes
This PR improves and fixes the behavior of `herokux_formation_autoscaling` in the following ways:
* Deletion will now disable the autoscaling remotely and remove resource from state instead of just removing resource from state.
* Creation properly uses the correct API endpoint to create the resource. Prior behavior was to use the update API endpoint.
* Attribute renames for consistency with `heroku_formation`:
    * `herokux_formation_autoscaling.dyno_type` ===> `herokux_formation_autoscaling.dyno_size`
    * `herokux_formation_autoscaling.formation` ===> `herokux_formation_autoscaling.process_type`
* Documentation overhaul `herokux_formation_autoscaling`:
    * Detail potential issues when using this resource.
    * Update verbage to indicate a harmonious relationship with `heroku_formation`. Prior documentation stated one should not use `heroku_formation` and `herokux_formation_autoscaling` simultaneously.

## Reference
_Documenting API behavior_

### When an app is just created, are there any monitors?
No, there are no monitors. API response returns `[]`.

### When an app is created and a slug is released (or `git push heroku master`), are there any monitor?
No, there are no monitors. API response returns `[]`, even if the dyno type moves from 'shared' to 'performance'.

### Original `POST` request
```json
{
   "is_active":true,
   "action_type":"scale",
   "op":"GREATER_OR_EQUAL",
   "period":1,
   "min_quantity":5,
   "max_quantity":7,
   "value":1000,
   "notification_period":1440,
   "playbook_url":null,
   "name":"LATENCY_SCALE",
   "notification_channels":[
      "app"
   ],
   "dyno_size":"Performance-M",
   "quantity":1
}
```

## Tidbits
- When autoscaling is first set, the request is a `POST`.
- Cannot `POST` to the endpoint again. Returns 500.

## API schema