### PR TITLE
Fix unsupported body type when updating settings for herokux_data_connector

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -15,7 +15,11 @@ build: fmtcheck
 install: fmtcheck
 	make fmt
 	make build
+	mkdir -p ~/.terraform.d/plugins/${OS}_amd64/${FILE_NAME}
 	cp ${GOPATH}/bin/terraform-provider-${PKG_NAME} ~/.terraform.d/plugins/${OS}_amd64/${FILE_NAME}
+	# Support for terraform 0.13+ plugin lookup path
+	mkdir -p ~/.terraform.d/plugins/registry.terraform.io/davidji99/${PKG_NAME}/${VERSION}/${OS}_amd64
+	cp ${GOPATH}/bin/terraform-provider-${PKG_NAME} ~/.terraform.d/plugins/registry.terraform.io/davidji99/${PKG_NAME}/${VERSION}/${OS}_amd64/${FILE_NAME}
 
 release: fmtcheck
 	scripts/build-release

--- a/api/postgres/data_connector.go
+++ b/api/postgres/data_connector.go
@@ -176,11 +176,11 @@ func (p *Postgres) ResumeDataConnector(id string) (*simpleresty.Response, error)
 //
 // Reference: https://devcenter.heroku.com/articles/heroku-data-connectors#update-configuration
 func (p *Postgres) UpdateDataConnectorSettings(id string, opts *DataConnectSettings) (*DataConnector, *simpleresty.Response, error) {
-	var result *DataConnector
+	var result DataConnector
 	urlStr := p.http.RequestURL("/data/cdc/v0/connectors/%s", id)
 
 	// Execute the request
-	response, resume := p.http.Patch(urlStr, &result, &opts)
+	response, resume := p.http.Patch(urlStr, &result, opts)
 
-	return result, response, resume
+	return &result, response, resume
 }


### PR DESCRIPTION
When trying to update the settings on a `herokux_data_connector` resource:

```hcl
settings = {
    "time.precision.mode" = "connect"
}
```

we are getting the following error:

```
unsupported 'Body' type/value
```

I eventually traced this back through simpleresty to go-resty to 

https://github.com/go-resty/resty/blob/bcec4e0910e82afff8e1e159e83e734739e9229f/middleware.go#L460-L467

It looks like `opts` is already a pointer to `DataConnectSettings` and by taking another pointer, the `kind` variable in the above code block is of `reflect.Ptr` and it falls through to the error message I was getting. I also noticed the same thing was happening with the result. I'm using terraform `v0.13.5` and was able to build this into the modules directory and was able to successfully update the settings on our data connector.
