### PR TITLE
Some tweaks to data connector resource

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ website/node_modules
 *.iml
 *.test
 *.iml
+example/
 
 website/vendor
 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -15,9 +15,10 @@ build: fmtcheck
 install: fmtcheck
 	make fmt
 	make build
-	mkdir -p ~/.terraform.d/plugins/${OS}_amd64/${FILE_NAME}
+	mkdir -p ~/.terraform.d/plugins/${OS}_amd64
 	cp ${GOPATH}/bin/terraform-provider-${PKG_NAME} ~/.terraform.d/plugins/${OS}_amd64/${FILE_NAME}
-	# Support for terraform 0.13+ plugin lookup path
+
+	# Support for terraform v0.13+ plugin lookup path
 	mkdir -p ~/.terraform.d/plugins/registry.terraform.io/davidji99/${PKG_NAME}/${VERSION}/${OS}_amd64
 	cp ${GOPATH}/bin/terraform-provider-${PKG_NAME} ~/.terraform.d/plugins/registry.terraform.io/davidji99/${PKG_NAME}/${VERSION}/${OS}_amd64/${FILE_NAME}
 

--- a/api/postgres/data_connector.go
+++ b/api/postgres/data_connector.go
@@ -87,9 +87,9 @@ type DataConnectSettings struct {
 }
 
 // ListDataConnectors retrieves all data connectors for an app.
-func (p *Postgres) ListDataConnectors(nameOrID string) ([]*DataConnector, *simpleresty.Response, error) {
+func (p *Postgres) ListDataConnectors(appNameOrID string) ([]*DataConnector, *simpleresty.Response, error) {
 	var result []*DataConnector
-	urlStr := p.http.RequestURL("/data/cdc/v0/apps/%s", nameOrID)
+	urlStr := p.http.RequestURL("/data/cdc/v0/apps/%s", appNameOrID)
 
 	// Execute the request
 	response, getErr := p.http.Get(urlStr, &result, nil)

--- a/api/postgres/data_connector.go
+++ b/api/postgres/data_connector.go
@@ -87,9 +87,11 @@ type DataConnectSettings struct {
 }
 
 // ListDataConnectors retrieves all data connectors for an app.
-func (p *Postgres) ListDataConnectors(appNameOrID string) ([]*DataConnector, *simpleresty.Response, error) {
+//
+// Note: Only the Heroku app name is acceptable here, not its UUID.
+func (p *Postgres) ListDataConnectors(appName string) ([]*DataConnector, *simpleresty.Response, error) {
 	var result []*DataConnector
-	urlStr := p.http.RequestURL("/data/cdc/v0/apps/%s", appNameOrID)
+	urlStr := p.http.RequestURL("/data/cdc/v0/apps/%s", appName)
 
 	// Execute the request
 	response, getErr := p.http.Get(urlStr, &result, nil)
@@ -173,6 +175,10 @@ func (p *Postgres) ResumeDataConnector(id string) (*simpleresty.Response, error)
 }
 
 // UpdateDataConnectorSettings updates the settings for a Data Connector.
+//
+// This endpoint does not provide any status of the update request. Users will need to poll and check
+// to confirm the desired settings are actually applied remotely. Subsequent updates will return a 422
+// if a prior update has not been fully applied to the data connector.
 //
 // Reference: https://devcenter.heroku.com/articles/heroku-data-connectors#update-configuration
 func (p *Postgres) UpdateDataConnectorSettings(id string, opts *DataConnectSettings) (*DataConnector, *simpleresty.Response, error) {

--- a/api/postgres/data_connector.go
+++ b/api/postgres/data_connector.go
@@ -178,7 +178,8 @@ func (p *Postgres) ResumeDataConnector(id string) (*simpleresty.Response, error)
 //
 // This endpoint does not provide any status of the update request. Users will need to poll and check
 // to confirm the desired settings are actually applied remotely. Subsequent updates will return a 422
-// if a prior update has not been fully applied to the data connector.
+// if a prior update has not been fully applied to the data connector. Additionally, it is not possible to null out
+// an existing settings value.
 //
 // Reference: https://devcenter.heroku.com/articles/heroku-data-connectors#update-configuration
 func (p *Postgres) UpdateDataConnectorSettings(id string, opts *DataConnectSettings) (*DataConnector, *simpleresty.Response, error) {

--- a/docs/index.md
+++ b/docs/index.md
@@ -186,7 +186,10 @@ Only a single `timeouts` block may be specified, and it supports the following a
     * `data_connector_delete_timeout` - (Optional) The number of minutes to wait for a data connector to be deleted.
     Defaults to 10 minutes. Minimum required is 3 minutes.
 
-    * `data_connector_update_timeout` - (Optional) The number of minutes to wait for a data connector to be updated.
+    * `data_connector_status_update_timeout` - (Optional) The number of minutes to wait for a data connector status to be updated.
+    Defaults to 10 minutes. Minimum required is 5 minutes.
+
+    * `data_connector_settings_update_timeout` - (Optional) The number of minutes to wait for a data connector settings to be updated.
     Defaults to 10 minutes. Minimum required is 5 minutes.
 
     * `postgres_credential_create_timeout` - (Optional) The number of minutes to wait for a postgres credential to be created.

--- a/docs/resources/data_connector.md
+++ b/docs/resources/data_connector.md
@@ -83,7 +83,10 @@ By default, the data connector is `available` on initial creation. Please also n
 * `excluded_columns` - `<list(string)>` List of columns to exclude.
 
 * `settings` - `<map>` Properties of the connector. Please visit [this article](https://devcenter.heroku.com/articles/heroku-data-connectors#update-configuration)
-for a list of valid properties that can be set for this attribute.
+for a list of valid properties that can be set for this attribute. Please also note the following:
+
+    * Due to API limitations, settings that are removed do not get unset remotely. Therefore, if you wish to remove a settings,
+      please set its value to the default value as mentioned in the article above and keep the setting in your configuration.
 
 -> **IMPORTANT!**
 The only updatable attributes are `settings` and `state`. All other attribute modifications will result
@@ -94,6 +97,8 @@ in destruction and recreation.
 The following attributes are exported:
 
 * `status` - The status of data connector.
+
+* `lag` - The lag of the data connector.
 
 ## Import
 

--- a/docs/resources/data_connector.md
+++ b/docs/resources/data_connector.md
@@ -93,10 +93,13 @@ The following attributes are exported:
 
 ## Import
 
-An existing data connector can be imported using the data connector UUID.
+An existing data connector can be imported using a composite value of the app name and data connector name
+separated by a colon.
+
+The simplest way to get the data connector name is via the `heroku data:connectors:list --app APP` command.
 
 For example:
 
 ```shell script
-$ terraform import herokux_data_connector.foobar "6f4a392b-914b-4e3e-9362-7c07bbab9cde"
+$ terraform import herokux_data_connector.foobar "APP_NAME:DATA_CONNECTOR_NAME"
 ```

--- a/docs/resources/data_connector.md
+++ b/docs/resources/data_connector.md
@@ -100,9 +100,13 @@ The following attributes are exported:
 
 * `lag` - The lag of the data connector.
 
+* `source_app_name` - The source's app name.
+
+* `store_app_name` - The store's app name.
+
 ## Import
 
-An existing data connector can be imported using a composite value of the app name and data connector name
+An existing data connector can be imported using a composite value of the source app name and data connector name
 separated by a colon.
 
 The simplest way to get the data connector name is via the `heroku data:connectors:list --app APP` command.
@@ -110,5 +114,5 @@ The simplest way to get the data connector name is via the `heroku data:connecto
 For example:
 
 ```shell script
-$ terraform import herokux_data_connector.foobar "APP_NAME:DATA_CONNECTOR_NAME"
+$ terraform import herokux_data_connector.foobar "SOURCE_APP_NAME:DATA_CONNECTOR_NAME"
 ```

--- a/docs/resources/data_connector.md
+++ b/docs/resources/data_connector.md
@@ -28,9 +28,13 @@ or philosophical beliefs, trade-union membership, information concerning health 
 physical or mental health; and information related to the provision or payment of health care.
 
 ### Resource Timeouts
-During creation, modification and deletion, this resource checks the status of the data connector.
-All the aforementioned timeouts can be customized via the `timeouts.data_connector_create_timeout`, `timeouts.data_connector_delete_timeout`
-and `timeouts.data_connector_update_timeout` attributes in your `provider` block.
+During creation, modification and deletion, this resource checks the progress of the action you took for the `apply`.
+All the aforementioned timeouts can be customized via the following attributes in your `provider` block:
+
+* `tdata_connector_create_timeout`
+* `tdata_connector_delete_timeout`
+* `tdata_connector_status_update_timeout`
+* `tdata_connector_settings_update_timeout`
 
 For example:
 
@@ -39,7 +43,7 @@ provider "herokux" {
   timeouts {
     data_connector_create_timeout = 20
     data_connector_delete_timeout = 20
-    data_connector_update_timeout = 20
+    data_connector_status_update_timeout = 20
   }
 }
 ```
@@ -78,8 +82,8 @@ By default, the data connector is `available` on initial creation. Please also n
 
 * `excluded_columns` - `<list(string)>` List of columns to exclude.
 
-* `settings` - `<map>` Properties of the connector. Please [visit](https://devcenter.heroku.com/articles/heroku-data-connectors#update-configuration)
-this article for more information.
+* `settings` - `<map>` Properties of the connector. Please visit [this article](https://devcenter.heroku.com/articles/heroku-data-connectors#update-configuration)
+for a list of valid properties that can be set for this attribute.
 
 -> **IMPORTANT!**
 The only updatable attributes are `settings` and `state`. All other attribute modifications will result

--- a/herokux/config.go
+++ b/herokux/config.go
@@ -30,7 +30,7 @@ const (
 	DefaultPrivatelinkDeleteTimeout                = int64(15)
 	DefaultPrivatelinkAllowedAccountsAddTimeout    = int64(10)
 	DefaultPrivatelinkAllowedAccountsRemoveTimeout = int64(10)
-	DefaultDataConnectorCreateTimeout              = int64(10)
+	DefaultDataConnectorCreateTimeout              = int64(20)
 	DefaultDataConnectorSettingsUpdateTimeout      = int64(10)
 	DefaultDataConnectorDeleteTimeout              = int64(10)
 	DefaultDataConnectorStatusUpdateTimeout        = int64(10)

--- a/herokux/config.go
+++ b/herokux/config.go
@@ -31,8 +31,9 @@ const (
 	DefaultPrivatelinkAllowedAccountsAddTimeout    = int64(10)
 	DefaultPrivatelinkAllowedAccountsRemoveTimeout = int64(10)
 	DefaultDataConnectorCreateTimeout              = int64(10)
+	DefaultDataConnectorSettingsUpdateTimeout      = int64(10)
 	DefaultDataConnectorDeleteTimeout              = int64(10)
-	DefaultDataConnectorUpdateTimeout              = int64(10)
+	DefaultDataConnectorStatusUpdateTimeout        = int64(10)
 	DefaultPostgresCredentialCreateTimeout         = int64(10)
 	DefaultPostgresCredentialDeleteTimeout         = int64(10)
 	DefaultPrivateSpaceCreateTimeout               = int64(20)
@@ -75,8 +76,9 @@ type Config struct {
 	PrivatelinkAllowedAccountsAddTimeout    int64
 	PrivatelinkAllowedAccountsRemoveTimeout int64
 	DataConnectorCreateTimeout              int64
+	DataConnectorSettingsUpdateTimeout      int64
 	DataConnectorDeleteTimeout              int64
-	DataConnectorUpdateTimeout              int64
+	DataConnectorStatusUpdateTimeout        int64
 	PostgresCredentialCreateTimeout         int64
 	PostgresCredentialDeleteTimeout         int64
 	PrivateSpaceCreateTimeout               int64
@@ -102,8 +104,9 @@ func NewConfig() *Config {
 		PrivatelinkAllowedAccountsAddTimeout:    DefaultPrivatelinkAllowedAccountsAddTimeout,
 		PrivatelinkAllowedAccountsRemoveTimeout: DefaultPrivatelinkAllowedAccountsRemoveTimeout,
 		DataConnectorCreateTimeout:              DefaultDataConnectorCreateTimeout,
+		DataConnectorSettingsUpdateTimeout:      DefaultDataConnectorSettingsUpdateTimeout,
 		DataConnectorDeleteTimeout:              DefaultDataConnectorDeleteTimeout,
-		DataConnectorUpdateTimeout:              DefaultDataConnectorUpdateTimeout,
+		DataConnectorStatusUpdateTimeout:        DefaultDataConnectorStatusUpdateTimeout,
 		PostgresCredentialCreateTimeout:         DefaultPostgresCredentialCreateTimeout,
 		PostgresCredentialDeleteTimeout:         DefaultPostgresCredentialDeleteTimeout,
 		PrivateSpaceCreateTimeout:               DefaultPrivateSpaceCreateTimeout,
@@ -273,12 +276,16 @@ func (c *Config) applySchema(d *schema.ResourceData) (err error) {
 				c.DataConnectorCreateTimeout = int64(v)
 			}
 
+			if v, ok := timeoutsConfig["data_connector_settings_update_timeout"].(int); ok {
+				c.DataConnectorSettingsUpdateTimeout = int64(v)
+			}
+
 			if v, ok := timeoutsConfig["data_connector_delete_timeout"].(int); ok {
 				c.DataConnectorDeleteTimeout = int64(v)
 			}
 
-			if v, ok := timeoutsConfig["data_connector_update_timeout"].(int); ok {
-				c.DataConnectorUpdateTimeout = int64(v)
+			if v, ok := timeoutsConfig["data_connector_status_update_timeout"].(int); ok {
+				c.DataConnectorStatusUpdateTimeout = int64(v)
 			}
 
 			if v, ok := timeoutsConfig["postgres_credential_create_timeout"].(int); ok {

--- a/herokux/import_herokux_data_connector_test.go
+++ b/herokux/import_herokux_data_connector_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"testing"
 )
 
@@ -23,9 +24,21 @@ func TestAccHerokuxDataConnector_importBasic(t *testing.T) {
 			},
 			{
 				ResourceName:      "herokux_data_connector.foobar",
+				ImportStateIdFunc: testAccHerokuxDataConnectorImportStateIDFunc("herokux_data_connector.foobar"),
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
 		},
 	})
+}
+
+func testAccHerokuxDataConnectorImportStateIDFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("[ERROR] Not found: %s", resourceName)
+		}
+
+		return fmt.Sprintf("%s:%s", rs.Primary.Attributes["source_app_name"], rs.Primary.Attributes["name"]), nil
+	}
 }

--- a/herokux/provider.go
+++ b/herokux/provider.go
@@ -184,6 +184,13 @@ func New() *schema.Provider {
 							ValidateFunc: validation.IntAtLeast(10),
 						},
 
+						"data_connector_settings_update_timeout": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Default:      20,
+							ValidateFunc: validation.IntAtLeast(10),
+						},
+
 						"data_connector_delete_timeout": {
 							Type:         schema.TypeInt,
 							Optional:     true,
@@ -191,7 +198,7 @@ func New() *schema.Provider {
 							ValidateFunc: validation.IntAtLeast(3),
 						},
 
-						"data_connector_update_timeout": {
+						"data_connector_status_update_timeout": {
 							Type:         schema.TypeInt,
 							Optional:     true,
 							Default:      10,

--- a/herokux/resource_herokux_data_connector.go
+++ b/herokux/resource_herokux_data_connector.go
@@ -95,6 +95,16 @@ func resourceHerokuxDataConnector() *schema.Resource {
 				Computed: true,
 			},
 
+			"source_app_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"store_app_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			//"platform_version": {
 			//	Type:     schema.TypeString,
 			//	Optional: true,
@@ -257,6 +267,8 @@ func resourceHerokuxDataConnectorRead(ctx context.Context, d *schema.ResourceDat
 	d.Set("tables", dc.Tables)
 	d.Set("status", dc.Status.ToString())
 	d.Set("lag", dc.GetLag())
+	d.Set("source_app_name", dc.GetPostgresApp().GetName())
+	d.Set("store_app_name", dc.GetKafkaApp().GetName())
 
 	// Set the state attribute to be the same as status.
 	d.Set("state", dc.Status.ToString())

--- a/herokux/resource_herokux_data_connector_test.go
+++ b/herokux/resource_herokux_data_connector_test.go
@@ -8,6 +8,21 @@ import (
 	"testing"
 )
 
+/**
+To run these tests, you'll need a Kafka and Postgres addon. The postgres DB needs to have a `users` table.
+You can use the following psql to create a table after logging into the instance
+via `heroku pg:psql --app APP`:
+
+CREATE TABLE users (
+	user_id serial PRIMARY KEY,
+	username VARCHAR ( 50 ) UNIQUE NOT NULL,
+	password VARCHAR ( 50 ) NOT NULL,
+	email VARCHAR ( 255 ) UNIQUE NOT NULL,
+	created_on TIMESTAMP NOT NULL,
+	last_login TIMESTAMP
+);
+*/
+
 func TestAccHerokuxDataConnector_Basic(t *testing.T) {
 	postgresID := testAccConfig.GetAddonIDorSkip(t)
 	kafkaID := testAccConfig.GetKafkaIDorSkip(t)
@@ -81,6 +96,38 @@ func TestAccHerokuxDataConnector_Paused(t *testing.T) {
 	})
 }
 
+func TestAccHerokuxDataConnector_WithSettings(t *testing.T) {
+	postgresID := testAccConfig.GetAddonIDorSkip(t)
+	kafkaID := testAccConfig.GetKafkaIDorSkip(t)
+	name := fmt.Sprintf("tftest-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckHerokuxDataConnector_basicSettings(postgresID, kafkaID, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"herokux_data_connector.foobar", "source_id", postgresID),
+					resource.TestCheckResourceAttr(
+						"herokux_data_connector.foobar", "store_id", kafkaID),
+					resource.TestCheckResourceAttr(
+						"herokux_data_connector.foobar", "name", name),
+					helper.TestCheckTypeSetElemAttr("herokux_data_connector.foobar",
+						"tables.*", "public.users"),
+					resource.TestCheckResourceAttr(
+						"herokux_data_connector.foobar", "excluded_columns.#", "0"),
+					resource.TestCheckResourceAttr(
+						"herokux_data_connector.foobar", "settings.%", "0"),
+					resource.TestCheckResourceAttr(
+						"herokux_data_connector.foobar", "status", "available"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckHerokuxDataConnector_basic(postgresID, kafkaID, name string) string {
 	return fmt.Sprintf(`
 resource "herokux_data_connector" "foobar" {
@@ -100,6 +147,20 @@ resource "herokux_data_connector" "foobar" {
 	name = "%s"
 	state = "paused"
 	tables = ["public.users"]
+}
+`, postgresID, kafkaID, name)
+}
+
+func testAccCheckHerokuxDataConnector_basicSettings(postgresID, kafkaID, name string) string {
+	return fmt.Sprintf(`
+resource "herokux_data_connector" "foobar" {
+	source_id = "%s"
+	store_id = "%s"
+	name = "%s"
+	tables = ["public.users"]
+	settings = {
+		"decimal.handling.mode" = "precise"
+	}
 }
 `, postgresID, kafkaID, name)
 }

--- a/herokux/resource_herokux_data_connector_test.go
+++ b/herokux/resource_herokux_data_connector_test.go
@@ -86,6 +86,8 @@ func TestAccHerokuxDataConnector_Paused(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"herokux_data_connector.foobar", "state", "available"),
 					resource.TestCheckResourceAttrSet("herokux_data_connector.foobar", "lag"),
+					resource.TestCheckResourceAttrSet("herokux_data_connector.foobar", "source_app_name"),
+					resource.TestCheckResourceAttrSet("herokux_data_connector.foobar", "store_app_name"),
 				),
 			},
 			{
@@ -124,10 +126,12 @@ func TestAccHerokuxDataConnector_WithSettings(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"herokux_data_connector.foobar", "excluded_columns.#", "0"),
 					resource.TestCheckResourceAttr(
-						"herokux_data_connector.foobar", "settings.%", "0"),
+						"herokux_data_connector.foobar", "settings.%", "1"),
 					resource.TestCheckResourceAttr(
 						"herokux_data_connector.foobar", "status", "available"),
 					resource.TestCheckResourceAttrSet("herokux_data_connector.foobar", "lag"),
+					resource.TestCheckResourceAttrSet("herokux_data_connector.foobar", "source_app_name"),
+					resource.TestCheckResourceAttrSet("herokux_data_connector.foobar", "store_app_name"),
 				),
 			},
 		},

--- a/herokux/resource_herokux_data_connector_test.go
+++ b/herokux/resource_herokux_data_connector_test.go
@@ -49,6 +49,8 @@ func TestAccHerokuxDataConnector_Basic(t *testing.T) {
 						"herokux_data_connector.foobar", "settings.%", "0"),
 					resource.TestCheckResourceAttr(
 						"herokux_data_connector.foobar", "status", "available"),
+					resource.TestCheckResourceAttr(
+						"herokux_data_connector.foobar", "state", "available"),
 				),
 			},
 		},
@@ -81,6 +83,9 @@ func TestAccHerokuxDataConnector_Paused(t *testing.T) {
 						"herokux_data_connector.foobar", "settings.%", "0"),
 					resource.TestCheckResourceAttr(
 						"herokux_data_connector.foobar", "status", "available"),
+					resource.TestCheckResourceAttr(
+						"herokux_data_connector.foobar", "state", "available"),
+					resource.TestCheckResourceAttrSet("herokux_data_connector.foobar", "lag"),
 				),
 			},
 			{
@@ -122,6 +127,7 @@ func TestAccHerokuxDataConnector_WithSettings(t *testing.T) {
 						"herokux_data_connector.foobar", "settings.%", "0"),
 					resource.TestCheckResourceAttr(
 						"herokux_data_connector.foobar", "status", "available"),
+					resource.TestCheckResourceAttrSet("herokux_data_connector.foobar", "lag"),
 				),
 			},
 		},


### PR DESCRIPTION
One not so insignificant change introduced in this PR is an easier method to import data connectors using a composite value of `APP_NAME:DATA_CONNECTOR_NAME`.

Also need to add a loop to verify data connector settings are successfully updated.

----

- [x] Test creating data connectors
- [x] Test importing data connectors