### PR TITLE
Handle creating PG credentials when HA standby is not ready

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -31,7 +31,7 @@ test: fmtcheck
 		xargs -t -n4 go test -v $(TESTARGS) -timeout=30s -parallel=4
 
 testacc: fmtcheck
-	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 120m -ldflags="-X=github.com/davidji99/terraform-provider-${PKG_NAME}/version.ProviderVersion=test"
+	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 240m -ldflags="-X=github.com/davidji99/terraform-provider-${PKG_NAME}/version.ProviderVersion=test"
 
 vet:
 	@echo "go vet ."

--- a/api/postgres/database.go
+++ b/api/postgres/database.go
@@ -1,8 +1,11 @@
 package postgres
 
-import "github.com/davidji99/simpleresty"
+import (
+	"fmt"
+	"github.com/davidji99/simpleresty"
+)
 
-// Database represents a Heroku postgres database
+// Database represents a Heroku postgres database.
 type Database struct {
 	Following           *string         `json:"following,omitempty"`
 	HotStandby          *bool           `json:"hot_standby,omitempty"`
@@ -18,7 +21,7 @@ type Database struct {
 	Info                []*DatabaseInfo `json:"info,omitempty"`
 }
 
-// DatabaseLeader represents a database's leader
+// DatabaseLeader represents a database's leader.
 type DatabaseLeader struct {
 	AddonID *string `json:"addon_id,omitempty"`
 	Name    *string `json:"name,omitempty"`
@@ -31,7 +34,16 @@ type DatabaseInfo struct {
 	ResolveDBName *bool         `json:"resolve_db_name,omitempty"`
 }
 
-// DatabaseWaitStatus rerepresents the status of a database.
+func (d *Database) RetrieveSpecificInfo(name string) (*DatabaseInfo, error) {
+	for _, info := range d.Info {
+		if info.GetName() == name {
+			return info, nil
+		}
+	}
+	return nil, fmt.Errorf("specific DB info not found")
+}
+
+// DatabaseWaitStatus represents the status of a database.
 type DatabaseWaitStatus struct {
 	Status    *string `json:"message,omitempty"`
 	IsWaiting *string `json:"waiting?,omitempty"`
@@ -59,7 +71,7 @@ func (p *Postgres) GetDBWaitStatus(dbID string) (*DatabaseWaitStatus, *simpleres
 	return result, response, getErr
 }
 
-// UnfollowDatabase tells a follower DB to unfollow the leader DB.
+// UnfollowDB tells a follower DB to unfollow the leader DB.
 func (p *Postgres) UnfollowDB(dbID string) (*GenericResponse, *simpleresty.Response, error) {
 	var result *GenericResponse
 	urlStr := p.http.RequestURL("/client/v11/databases/%s/unfollow", dbID)

--- a/api/postgres/types.go
+++ b/api/postgres/types.go
@@ -70,7 +70,7 @@ func (s MTLSCertStatus) ToString() string {
 // DatabaseInfoName represents a database info name.
 type DatabaseInfoName string
 
-// DatabaseInfoNames represents database infor names.
+// DatabaseInfoNames represents database info names.
 var DatabaseInfoNames = struct {
 	PLAN       DatabaseInfoName
 	STATUS     DatabaseInfoName
@@ -95,6 +95,23 @@ var DatabaseInfoNames = struct {
 
 // ToString is a helper method to return the string of a DatabaseInfoName.
 func (s DatabaseInfoName) ToString() string {
+	return string(s)
+}
+
+// DatabaseInfoStatus represents a status for a database info status, such as High Availability (HA) or Fork/Follow status.
+type DatabaseInfoStatus string
+
+// DatabaseInfoStatuses represents database info statuses.
+var DatabaseInfoStatuses = struct {
+	TEMP_UNAVAILABLE DatabaseInfoStatus
+	AVAILABLE        DatabaseInfoStatus
+}{
+	TEMP_UNAVAILABLE: "Temporarily Unavailable",
+	AVAILABLE:        "Available",
+}
+
+// ToString is a helper method to return the string of a DatabaseInfoStatus.
+func (s DatabaseInfoStatus) ToString() string {
 	return string(s)
 }
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -199,7 +199,7 @@ Only a single `delays` block may be specified, and it supports the following arg
     * `postgres_credential_pre_create_verify_timeout` - (Optional) The number of minutes to wait for a postgres database
       to be available for credential creation. This is to address an edge scenario where one cannot create credentials immediately
       after a Premium, Private, or Shield postgres database is provisioned.
-      Defaults to 30 minutes. Minimum required is 20 minutes.
+      Defaults to 45 minutes. Minimum required is 20 minutes.
 
     * `postgres_credential_create_timeout` - (Optional) The number of minutes to wait for a postgres credential to be created.
       Defaults to 10 minutes. Minimum required is 5 minutes.

--- a/docs/index.md
+++ b/docs/index.md
@@ -138,69 +138,74 @@ and subsequent changes require the previous one to be completed first.
 Only a single `delays` block may be specified, and it supports the following arguments:
 
     * `postgres_settings_modify_delay` - (Optional) The number of minutes to wait for a postgres settings modification to be
-    properly reflected in Heroku. Defaults to 2 minutes. Minimum required is 1 minute.
+      properly reflected in Heroku. Defaults to 2 minutes. Minimum required is 1 minute.
 
     * `connect_mapping_modify_delay` - (Optional) The number of seconds to wait Heroku Connect mapping to be
-    properly reflected in Heroku. Defaults to 15 seconds. Minimum required is 5 seconds.
+      properly reflected in Heroku. Defaults to 15 seconds. Minimum required is 5 seconds.
 
 * `timeouts` - (Optional) Timeouts define a max duration the provider will wait for certain resources
-to be properly modified before proceeding with further action(s). Each timeout's polling intervals is set to 20 seconds.
-Only a single `timeouts` block may be specified, and it supports the following arguments:
+  to be properly modified before proceeding with further action(s). Each timeout's polling intervals is set to 20 seconds.
+  Only a single `timeouts` block may be specified, and it supports the following arguments:
 
     * `mtls_provision_timeout` - (Optional) The number of minutes to wait for a MTLS configuration
-    to be provisioned on a database. Defaults to 10 minutes. Minimum required (based off of Heroku documentation) is 5 minutes.
+      to be provisioned on a database. Defaults to 10 minutes. Minimum required (based off of Heroku documentation) is 5 minutes.
 
     * `mtls_deprovision_timeout` - (Optional) The number of minutes to wait for a MTLS configuration
-    to be deprovisioned from a database. Defaults to 10 minutes. Minimum required (based off of Heroku documentation) is 5 minutes.
+      to be deprovisioned from a database. Defaults to 10 minutes. Minimum required (based off of Heroku documentation) is 5 minutes.
 
     * `mtls_iprule_create_timeout` - (Optional) The number of minutes to wait for a MTLS IP rule
-    to be created/authorized for a database. Defaults to 10 minutes.
+      to be created/authorized for a database. Defaults to 10 minutes.
 
     * `mtls_certificate_create_timeout` - (Optional) The number of minutes to wait for a MTLS certificate
-    to be create and ready for use. Defaults to 10 minutes.
+      to be create and ready for use. Defaults to 10 minutes.
 
     * `mtls_certificate_delete_timeout` - (Optional) The number of minutes to wait for a MTLS certificate
-    to be deleted. Defaults to 10 minutes.
+      to be deleted. Defaults to 10 minutes.
 
     * `kafka_cg_create_timeout` - (Optional) The number of minutes to wait for a Kafka consumer group to be created.
-    Defaults to 10 minutes.
+      Defaults to 10 minutes.
 
     * `kafka_cg_delete_timeout` - (Optional) The number of minutes to wait for a Kafka consumer group to be deleted.
-    Defaults to 10 minutes.
+      Defaults to 10 minutes.
 
     * `kafka_topic_create_timeout` - (Optional) The number of minutes to wait for a Kafka topic to ready. Ready state
-    is achieved when the topic itself is provisioned with the specified number of partitions.
-    Defaults to 10 minutes. Minimum required is 3 minutes.
+      is achieved when the topic itself is provisioned with the specified number of partitions.
+      Defaults to 10 minutes. Minimum required is 3 minutes.
 
     * `kafka_topic_update_timeout` - (Optional) The number of minutes to wait for a Kafka topic to updated remotely.
-    Defaults to 10 minutes. Minimum required is 3 minutes.
+      Defaults to 10 minutes. Minimum required is 3 minutes.
 
     * `privatelink_create_timeout` - (Optional) The number of minutes to wait for a privatelink to be provisioned.
-    Defaults to 15 minutes. Minimum required is 5 minutes.
+      Defaults to 15 minutes. Minimum required is 5 minutes.
 
     * `privatelink_delete_timeout` - (Optional) The number of minutes to wait for a privatelink to be deprovisioned.
-    Defaults to 15 minutes. Minimum required is 5 minutes.
+      Defaults to 15 minutes. Minimum required is 5 minutes.
 
     * `privatelink_allowed_acccounts_add_timeout` - (Optional) The number of minutes to wait for allowed accounts
-    to become active for a privatelink. Defaults to 10 minutes. Minimum required is 2 minutes.
+      to become active for a privatelink. Defaults to 10 minutes. Minimum required is 2 minutes.
 
     * `data_connector_create_timeout` - (Optional) The number of minutes to wait for a data connector to be provisioned.
-    Defaults to 20 minutes. Minimum required is 10 minutes.
+      Defaults to 20 minutes. Minimum required is 10 minutes.
 
     * `data_connector_delete_timeout` - (Optional) The number of minutes to wait for a data connector to be deleted.
-    Defaults to 10 minutes. Minimum required is 3 minutes.
+      Defaults to 10 minutes. Minimum required is 3 minutes.
 
     * `data_connector_status_update_timeout` - (Optional) The number of minutes to wait for a data connector status to be updated.
-    Defaults to 10 minutes. Minimum required is 5 minutes.
+      Defaults to 10 minutes. Minimum required is 5 minutes.
 
     * `data_connector_settings_update_timeout` - (Optional) The number of minutes to wait for a data connector settings to be updated.
-    Defaults to 10 minutes. Minimum required is 5 minutes.
+      Defaults to 10 minutes. Minimum required is 5 minutes.
+
+    * `postgres_credential_pre_create_verify_timeout` - (Optional) The number of minutes to wait for a postgres database
+      to be available for credential creation. This is to address an edge scenario where one cannot create credentials immediately
+      after a Premium, Private, or Shield postgres database is provisioned.
+      Defaults to 60 minutes. Minimum required is 30 minutes.
 
     * `postgres_credential_create_timeout` - (Optional) The number of minutes to wait for a postgres credential to be created.
-    Defaults to 10 minutes. Minimum required is 5 minutes.
+      Defaults to 10 minutes. Minimum required is 5 minutes.
 
     * `postgres_credential_delete_timeout` - (Optional) The number of minutes to wait for a postgres credential to be deleted.
-    Defaults to 10 minutes. Minimum required is 5 minutes.
+      Defaults to 10 minutes. Minimum required is 5 minutes.
 
     * `shield_private_space_create_timeout` - (Optional) The number of minutes to wait for a shield private space
-    to be provisioned. Defaults to 20 minutes. Minimum required is 10 minutes.
+      to be provisioned. Defaults to 20 minutes. Minimum required is 10 minutes.

--- a/docs/index.md
+++ b/docs/index.md
@@ -199,7 +199,7 @@ Only a single `delays` block may be specified, and it supports the following arg
     * `postgres_credential_pre_create_verify_timeout` - (Optional) The number of minutes to wait for a postgres database
       to be available for credential creation. This is to address an edge scenario where one cannot create credentials immediately
       after a Premium, Private, or Shield postgres database is provisioned.
-      Defaults to 60 minutes. Minimum required is 30 minutes.
+      Defaults to 30 minutes. Minimum required is 20 minutes.
 
     * `postgres_credential_create_timeout` - (Optional) The number of minutes to wait for a postgres credential to be created.
       Defaults to 10 minutes. Minimum required is 5 minutes.

--- a/docs/resources/app_container_release.md
+++ b/docs/resources/app_container_release.md
@@ -35,9 +35,9 @@ data "herokux_registry_image" "foobar" {
 }
 
 resource "herokux_app_container_release" "foobar" {
-	app_id = heroku_app.foobar.uuid
-	image_id = data.herokux_registry_image.foobar.digest
-	process_type = "web"
+  app_id = heroku_app.foobar.uuid
+  image_id = data.herokux_registry_image.foobar.digest
+  process_type = "web"
 }
 
 # Update the web formation for the foobar application's web process type

--- a/docs/resources/app_github_integration.md
+++ b/docs/resources/app_github_integration.md
@@ -27,7 +27,7 @@ resource "heroku_app" "staging" {
   region = "us"
 
   organization {
-    name = "my-cool-team"
+    name = "my_org"
   }
 }
 

--- a/docs/resources/app_webhook.md
+++ b/docs/resources/app_webhook.md
@@ -15,12 +15,21 @@ for a wide variety of events.
 ## Example Usage
 
 ```hcl-terraform
+resource "heroku_app" "foobar" {
+  name   = "my_foobar_app"
+  region = "us"
+
+  organization {
+    name = "my_org"
+  }
+}
+
 resource "herokux_app_webhook" "foobar" {
-	app_id = "6fae1ee0-c034-4775-a798-890bc64f98eb"
-	level = "notify"
-	url = "https://example.com/hooks"
-	event_types = ["api:addon-attachment"]
-	name = "my-custom-webhook-name"
+  app_id = heroku_app.foobar.uuid
+  level = "notify"
+  url = "https://example.com/hooks"
+  event_types = ["api:addon-attachment"]
+  name = "my-custom-webhook-name"
 }
 ```
 

--- a/docs/resources/connect_mappings.md
+++ b/docs/resources/connect_mappings.md
@@ -97,9 +97,23 @@ provider "herokux" {
 Using shell-style "here doc" syntax:
 
 ```hcl-terraform
+resource "heroku_app" "foobar" {
+  name   = "my_foobar_app"
+  region = "us"
+
+  organization {
+    name = "my_org"
+  }
+}
+
+resource "heroku_addon" "connect" {
+  app  = heroku_app.foobar.name
+  plan = "heroku-shield:free"
+}
+
 resource "herokux_connect_mappings" "foobar" {
-  app_id = "33d4631b-2c77-4b99-b657-752ad8f68322"
-  connect_id = "7f1f2784-2c35-4efa-b0cd-544c9784fe9b"
+  app_id = heroku_app.foobar.uuid
+  connect_id = heroku_addon.connect.id
   mappings = <<-EOF
 {
     "mappings": [
@@ -136,9 +150,23 @@ EOF
 Using Terraform's `file` function:
 
 ```hcl-terraform
+resource "heroku_app" "foobar" {
+  name   = "my_foobar_app"
+  region = "us"
+
+  organization {
+    name = "my_org"
+  }
+}
+
+resource "heroku_addon" "connect" {
+  app  = heroku_app.foobar.name
+  plan = "heroku-shield:free"
+}
+
 resource "herokux_connect_mappings" "foobar" {
-  app_id = "33d4631b-2c77-4b99-b657-752ad8f68322"
-  connect_id = "7f1f2784-2c35-4efa-b0cd-544c9784fe9b"
+  app_id = heroku_app.foobar.uuid
+  connect_id = heroku_addon.connect.id
   mappings = file("test-fixtures/path_to_mappings.json")
 }
 ```
@@ -151,9 +179,23 @@ data "local_file" "mapping_json_file" {
   filename = "${path.module}/foo.bar"
 }
 
+resource "heroku_app" "foobar" {
+  name   = "my_foobar_app"
+  region = "us"
+
+  organization {
+    name = "my_org"
+  }
+}
+
+resource "heroku_addon" "connect" {
+  app  = heroku_app.foobar.name
+  plan = "heroku-shield:free"
+}
+
 resource "herokux_connect_mappings" "foobar" {
-  app_id = "33d4631b-2c77-4b99-b657-752ad8f68322"
-  connect_id = "7f1f2784-2c35-4efa-b0cd-544c9784fe9b"
+  app_id = heroku_app.foobar.uuid
+  connect_id = heroku_addon.connect.id
   mappings = data.local_file.mapping_json_file.content
 }
 ```

--- a/docs/resources/data_connector.md
+++ b/docs/resources/data_connector.md
@@ -51,11 +51,30 @@ provider "herokux" {
 ## Example Usage
 
 ```hcl-terraform
+resource "heroku_app" "foobar" {
+  name   = "my_foobar_app"
+  region = "us"
+
+  organization {
+    name = "my_org"
+  }
+}
+
+resource "heroku_addon" "database" {
+  app  = heroku_app.foobar.name
+  plan = "heroku-postgresql:premium-0"
+}
+
+resource "heroku_addon" "kafka" {
+  app  = heroku_app.foobar.name
+  plan = "heroku-kafka:standard-0"
+}
+
 resource "herokux_data_connector" "foobar" {
-	source_id = "33d4631b-2c77-4b99-b657-752ad8f68322"
-	store_id = "7f1f2784-2c35-4efa-b0cd-544c9784fe9b"
-	name = "my-custom-connector-name"
-	tables = ["public.users"]
+  source_id = heroku_addon.database.id
+  store_id = heroku_addon.kafka.id
+  name = "my-custom-connector-name"
+  tables = ["public.users"]
 }
 ```
 

--- a/docs/resources/kafka_consumer_group.md
+++ b/docs/resources/kafka_consumer_group.md
@@ -29,9 +29,23 @@ provider "herokux" {
 ## Example Usage
 
 ```hcl-terraform
+resource "heroku_app" "foobar" {
+  name   = "my_foobar_app"
+  region = "us"
+
+  organization {
+    name = "my_org"
+  }
+}
+
+resource "heroku_addon" "kafka" {
+  app  = heroku_app.foobar.name
+  plan = "heroku-kafka:standard-0"
+}
+
 resource "herokux_kafka_consumer_group" "foobar" {
-	kafka_id = "2bccd770-e7aa-4865-98d2-6e222f2d2582"
-	name = "my new group"
+ kafka_id = heroku_addon.kafka.id
+ name = "my new group"
 }
 ```
 

--- a/docs/resources/kafka_topic.md
+++ b/docs/resources/kafka_topic.md
@@ -44,13 +44,27 @@ provider "herokux" {
 ## Example Usage
 
 ```hcl-terraform
+resource "heroku_app" "foobar" {
+  name   = "my_foobar_app"
+  region = "us"
+
+  organization {
+    name = "my_org"
+  }
+}
+
+resource "heroku_addon" "kafka" {
+  app  = heroku_app.foobar.name
+  plan = "heroku-kafka:standard-0"
+}
+
 resource "herokux_kafka_topic" "foobar" {
-	kafka_id = "11db7126-0cb7-4b42-a64a-d4ae70110216"
-	name = "my-cool-topic"
-	partitions = 8
-	replication_factor = 3
-	retention_time = "2d"
-	compaction = true
+  kafka_id = heroku_addon.kafka.id
+  name = "my-cool-topic"
+  partitions = 8
+  replication_factor = 3
+  retention_time = "2d"
+  compaction = true
 }
 ```
 

--- a/docs/resources/oauth_authorization.md
+++ b/docs/resources/oauth_authorization.md
@@ -37,10 +37,10 @@ In this scenario, the resource will remove itself from state and be created agai
 
 ```hcl-terraform
 resource "herokux_oauth_authorization" "foobar" {
-	scope = ["read"]
-	auth_api_key_name = "MYBOTUSER"
-	time_to_live = 100000
-	description = "This is an oauth authorization test from Terraform"
+  scope = ["read"]
+  auth_api_key_name = "MYBOTUSER"
+  time_to_live = 100000
+  description = "This is an oauth authorization test from Terraform"
 }
 ```
 

--- a/docs/resources/postgres_backup_schedule.md
+++ b/docs/resources/postgres_backup_schedule.md
@@ -24,8 +24,22 @@ are likely to fail.
 ## Example Usage
 
 ```hcl-terraform
+resource "heroku_app" "foobar" {
+  name   = "my_foobar_app"
+  region = "us"
+
+  organization {
+    name = "my_org"
+  }
+}
+
+resource "heroku_addon" "database" {
+  app  = heroku_app.foobar.name
+  plan = "heroku-postgresql:premium-0"
+}
+
 resource "herokux_postgres_backup_schedule" "foobar" {
-  postgres_id = "2508ebbd-74bb-4e81-a63c-d193d2bd5716"
+  postgres_id = heroku_addon.database.id
   hour        = 3
   timezone    = "Australia/Perth"
 }

--- a/docs/resources/postgres_data_link.md
+++ b/docs/resources/postgres_data_link.md
@@ -38,10 +38,29 @@ this data link setup.
 ## Example Usage
 
 ```hcl-terraform
+resource "heroku_app" "foobar" {
+  name   = "my_foobar_app"
+  region = "us"
+
+  organization {
+    name = "my_org"
+  }
+}
+
+resource "heroku_addon" "local_db" {
+  app  = heroku_app.foobar.name
+  plan = "heroku-postgresql:premium-0"
+}
+
+resource "heroku_addon" "remote_db" {
+  app  = heroku_app.foobar.name
+  plan = "heroku-postgresql:premium-0"
+}
+
 resource "herokux_postgres_data_link" "foobar" {
-	local_db_id = "6fae1ee0-c034-4775-a798-890bc64f98eb"
-	remote_db_name = "postgresql-spherical-123456"
-	name = "my_custom_data_l1nk_name"
+  local_db_id = heroku_addon.local_db.id
+  remote_db_name = heroku_addon.local_db.name
+  name = "my_custom_data_l1nk_name"
 }
 ```
 

--- a/docs/resources/postgres_maintenance_window.md
+++ b/docs/resources/postgres_maintenance_window.md
@@ -22,9 +22,23 @@ It is not possible to delete a maintenance window, so the resource will just be 
 ## Example Usage
 
 ```hcl-terraform
+resource "heroku_app" "foobar" {
+  name   = "my_foobar_app"
+  region = "us"
+
+  organization {
+    name = "my_org"
+  }
+}
+
+resource "heroku_addon" "database" {
+  app  = heroku_app.foobar.name
+  plan = "heroku-postgresql:premium-0"
+}
+
 resource "herokux_postgres_maintenance_window" "foobar" {
-	postgres_id = "717e9e8f-c4ad-4f45-9ac3-069ecb0fcd60"
-	window = "Mondays 10:30"
+  postgres_id = heroku_addon.database.id
+  window = "Mondays 10:30"
 }
 ```
 

--- a/docs/resources/postgres_mtls.md
+++ b/docs/resources/postgres_mtls.md
@@ -39,8 +39,22 @@ provider "herokux" {
 ## Example Usage
 
 ```hcl-terraform
+resource "heroku_app" "foobar" {
+  name   = "my_foobar_app"
+  region = "us"
+
+  organization {
+    name = "my_org"
+  }
+}
+
+resource "heroku_addon" "database" {
+  app  = heroku_app.foobar.name
+  plan = "heroku-postgresql:premium-0"
+}
+
 resource "herokux_postgres_mtls" "foobar" {
-	database_name = "my_database_name"
+  database_name = heroku_addon.database.name
 }
 ```
 
@@ -48,7 +62,8 @@ resource "herokux_postgres_mtls" "foobar" {
 
 The following arguments are supported:
 
-* `database_name` - (Required) `<string>` The name of the database. DO NOT use the database UUID.
+* `database_name` - (Required) `<string>` The name of the Postgres database name. DO NOT use the database UUID.
+For example, 'postgresql-slippery-18242'.
 
 ## Attributes Reference
 

--- a/docs/resources/postgres_mtls_certificate.md
+++ b/docs/resources/postgres_mtls_certificate.md
@@ -39,12 +39,28 @@ to create, please utilize Terraform's `count` or `for_each` expression to keep y
 ## Example Usage
 
 ```hcl-terraform
+resource "heroku_app" "foobar" {
+  name   = "my_foobar_app"
+  region = "us"
+
+  organization {
+    name = "my_org"
+  }
+}
+
+resource "heroku_addon" "database" {
+  app  = heroku_app.foobar.name
+  plan = "heroku-postgresql:premium-0"
+}
+
 resource "herokux_postgres_mtls" "foobar" {
-	database_name = "my_database_name"
+  database_name = heroku_addon.database.name
 }
 
 resource "herokux_postgres_mtls_certificate" "foobar" {
-	database_name = herokux_postgres_mtls.foobar.database_name
+  // This is not set to heroku_addon.database.name
+  // as MTLS needs to be provisioned before a certificate can be created.
+  database_name = herokux_postgres_mtls.foobar.database_name
 }
 ```
 

--- a/docs/resources/postgres_mtls_iprule.md
+++ b/docs/resources/postgres_mtls_iprule.md
@@ -37,14 +37,28 @@ to add, please utilize Terraform's `count` or `for_each` expression to keep your
 ## Example Usage
 
 ```hcl-terraform
+resource "heroku_app" "foobar" {
+  name   = "my_foobar_app"
+  region = "us"
+
+  organization {
+    name = "my_org"
+  }
+}
+
+resource "heroku_addon" "database" {
+  app  = heroku_app.foobar.name
+  plan = "heroku-postgresql:premium-0"
+}
+
 resource "herokux_postgres_mtls" "foobar" {
-	database_name = "my_database_name"
+  database_name = heroku_addon.database.name
 }
 
 resource "herokux_postgres_mtls_iprule" "foobar" {
-	database_name = herokux_postgres_mtls.foobar.database_name
-	cidr = "1.2.3.4/32"
-	description = "this is a test IP rule"
+  database_name = herokux_postgres_mtls.foobar.database_name
+  cidr = "1.2.3.4/32"
+  description = "this is a test IP rule"
 }
 ```
 

--- a/docs/resources/postgres_settings.md
+++ b/docs/resources/postgres_settings.md
@@ -36,12 +36,26 @@ provider "herokux" {
 ## Example Usage
 
 ```hcl-terraform
+resource "heroku_app" "foobar" {
+  name   = "my_foobar_app"
+  region = "us"
+
+  organization {
+    name = "my_org"
+  }
+}
+
+resource "heroku_addon" "database" {
+  app  = heroku_app.foobar.name
+  plan = "heroku-postgresql:premium-0"
+}
+
 resource "herokux_postgres_settings" "foobar" {
-	postgres_id = "867f0740-82f9-4b9d-9994-cfbae2011abc"
-	log_lock_waits = true
-	log_connections = false
-	log_min_duration_statement = 123
-	log_statement = "none"
+  postgres_id = heroku_addon.database.id
+  log_lock_waits = true
+  log_connections = false
+  log_min_duration_statement = 123
+  log_statement = "none"
 }
 ```
 

--- a/docs/resources/privatelink.md
+++ b/docs/resources/privatelink.md
@@ -41,9 +41,23 @@ provider "herokux" {
 ## Example Usage
 
 ```hcl-terraform
+resource "heroku_app" "foobar" {
+  name   = "my_foobar_app"
+  region = "us"
+
+  organization {
+    name = "my_org"
+  }
+}
+
+resource "heroku_addon" "database" {
+  app  = heroku_app.foobar.name
+  plan = "heroku-postgresql:premium-0"
+}
+
 resource "herokux_privatelink" "foobar" {
-	addon_id = "6e00025a-306c-406a-9f95-cda26bee2a86"
-	allowed_accounts = ["123456789123", "123456789124"]
+  addon_id = heroku_addon.database.id
+  allowed_accounts = ["123456789123", "123456789124"]
 }
 ```
 

--- a/docs/resources/redis_config.md
+++ b/docs/resources/redis_config.md
@@ -18,11 +18,25 @@ will remain the same until they are changed by `terraform` or `heroku redis:***`
 ## Example Usage
 
 ```hcl-terraform
+resource "heroku_app" "foobar" {
+  name   = "my_foobar_app"
+  region = "us"
+
+  organization {
+    name = "my_org"
+  }
+}
+
+resource "heroku_addon" "redis" {
+  app  = heroku_app.foobar.name
+  plan = "heroku-redis:premium-0"
+}
+
 resource "herokux_redis_config" "foobar" {
-	redis_id = "57d660e0-3d20-40b7-8d20-e77b95189e5a"
-	maxmemory_policy = "allkeys-lfu"
-	notify_keyspace_events = "K"
-	timeout = 500
+  redis_id = heroku_addon.redis.id
+  maxmemory_policy = "allkeys-lfu"
+  notify_keyspace_events = "K"
+  timeout = 500
 }
 ```
 

--- a/docs/resources/redis_maintenance_window.md
+++ b/docs/resources/redis_maintenance_window.md
@@ -21,9 +21,23 @@ It is not possible to delete a maintenance window, so the resource will just be 
 ## Example Usage
 
 ```hcl-terraform
+resource "heroku_app" "foobar" {
+  name   = "my_foobar_app"
+  region = "us"
+
+  organization {
+    name = "my_org"
+  }
+}
+
+resource "heroku_addon" "redis" {
+  app  = heroku_app.foobar.name
+  plan = "heroku-redis:premium-0"
+}
+
 resource "herokux_redis_maintenance_window" "foobar" {
-	redis_id = "717e9e8f-c4ad-4f45-9ac3-069ecb0fcd60"
-	window = "Mondays 10:30"
+  redis_id = heroku_addon.redis.id
+  window = "Mondays 10:30"
 }
 ```
 

--- a/helper/test/config.go
+++ b/helper/test/config.go
@@ -25,6 +25,7 @@ const (
 	TestConfigPipelineID
 	TestConfigGithubOrgRepo
 	TestConfigUserEmail
+	TestConfigOrganization
 	TestConfigAcceptanceTestKey
 )
 
@@ -43,6 +44,7 @@ var testConfigKeyToEnvName = map[TestConfigKey]string{
 	TestConfigPipelineID:          "HEROKUX_PIPELINE_ID",
 	TestConfigGithubOrgRepo:       "HEROKUX_GITHUB_ORG_REPO",
 	TestConfigUserEmail:           "HEROKUX_USER_EMAIL",
+	TestConfigOrganization:        "HEROKUX_ORGANIZATION",
 	TestConfigAcceptanceTestKey:   resource.TestEnvVar,
 }
 
@@ -144,4 +146,8 @@ func (t *TestConfig) GetGithubOrgRepoorSkip(testing *testing.T) (val string) {
 
 func (t *TestConfig) GetUserEmailorSkip(testing *testing.T) (val string) {
 	return t.GetOrSkip(testing, TestConfigUserEmail)
+}
+
+func (t *TestConfig) GetAnyOrganizationOrSkip(testing *testing.T) (val string) {
+	return t.GetOrSkip(testing, TestConfigOrganization)
 }

--- a/herokux/config.go
+++ b/herokux/config.go
@@ -34,7 +34,7 @@ const (
 	DefaultDataConnectorSettingsUpdateTimeout       = int64(10)
 	DefaultDataConnectorDeleteTimeout               = int64(10)
 	DefaultDataConnectorStatusUpdateTimeout         = int64(10)
-	DefaultPostgresCredentialPreCreateVerifyTimeout = int64(30)
+	DefaultPostgresCredentialPreCreateVerifyTimeout = int64(45)
 	DefaultPostgresCredentialCreateTimeout          = int64(10)
 	DefaultPostgresCredentialDeleteTimeout          = int64(10)
 	DefaultPrivateSpaceCreateTimeout                = int64(20)

--- a/herokux/config.go
+++ b/herokux/config.go
@@ -17,26 +17,27 @@ import (
 )
 
 const (
-	DefaultMTLSProvisionTimeout                    = int64(10)
-	DefaultMTLSMTLSDeprovisionTimeout              = int64(10)
-	DefaultMTLSIPRuleCreateTimeout                 = int64(10)
-	DefaultMTLSCertificateCreateTimeout            = int64(10)
-	DefaultMTLSCertificateDeleteTimeout            = int64(10)
-	DefaultKafkaCGCreateTimeout                    = int64(10)
-	DefaultKafkaCGDeleteTimeout                    = int64(10)
-	DefaultKafkaTopicCreateTimeout                 = int64(10)
-	DefaultKafkaTopicUpdateTimeout                 = int64(10)
-	DefaultPrivatelinkCreateTimeoutt               = int64(15)
-	DefaultPrivatelinkDeleteTimeout                = int64(15)
-	DefaultPrivatelinkAllowedAccountsAddTimeout    = int64(10)
-	DefaultPrivatelinkAllowedAccountsRemoveTimeout = int64(10)
-	DefaultDataConnectorCreateTimeout              = int64(20)
-	DefaultDataConnectorSettingsUpdateTimeout      = int64(10)
-	DefaultDataConnectorDeleteTimeout              = int64(10)
-	DefaultDataConnectorStatusUpdateTimeout        = int64(10)
-	DefaultPostgresCredentialCreateTimeout         = int64(10)
-	DefaultPostgresCredentialDeleteTimeout         = int64(10)
-	DefaultPrivateSpaceCreateTimeout               = int64(20)
+	DefaultMTLSProvisionTimeout                     = int64(10)
+	DefaultMTLSMTLSDeprovisionTimeout               = int64(10)
+	DefaultMTLSIPRuleCreateTimeout                  = int64(10)
+	DefaultMTLSCertificateCreateTimeout             = int64(10)
+	DefaultMTLSCertificateDeleteTimeout             = int64(10)
+	DefaultKafkaCGCreateTimeout                     = int64(10)
+	DefaultKafkaCGDeleteTimeout                     = int64(10)
+	DefaultKafkaTopicCreateTimeout                  = int64(10)
+	DefaultKafkaTopicUpdateTimeout                  = int64(10)
+	DefaultPrivatelinkCreateTimeout                 = int64(15)
+	DefaultPrivatelinkDeleteTimeout                 = int64(15)
+	DefaultPrivatelinkAllowedAccountsAddTimeout     = int64(10)
+	DefaultPrivatelinkAllowedAccountsRemoveTimeout  = int64(10)
+	DefaultDataConnectorCreateTimeout               = int64(20)
+	DefaultDataConnectorSettingsUpdateTimeout       = int64(10)
+	DefaultDataConnectorDeleteTimeout               = int64(10)
+	DefaultDataConnectorStatusUpdateTimeout         = int64(10)
+	DefaultPostgresCredentialPreCreateVerifyTimeout = int64(30)
+	DefaultPostgresCredentialCreateTimeout          = int64(10)
+	DefaultPostgresCredentialDeleteTimeout          = int64(10)
+	DefaultPrivateSpaceCreateTimeout                = int64(20)
 
 	DefaultPostgresSettingsModifyDelay = int64(2)
 	DefaultConnectMappingModifyDelay   = int64(15)
@@ -63,26 +64,27 @@ type Config struct {
 	kolkrabbiURL      string
 
 	// Custom Timeouts
-	MTLSProvisionTimeout                    int64
-	MTLSDeprovisionTimeout                  int64
-	MTLSIPRuleCreateTimeout                 int64
-	MTLSCertificateCreateTimeout            int64
-	MTLSCertificateDeleteTimeout            int64
-	KafkaCGCreateTimeout                    int64
-	KafkaCGDeleteTimeout                    int64
-	KafkaTopicCreateTimeout                 int64
-	KafkaTopicUpdateTimeout                 int64
-	PrivatelinkCreateTimeout                int64
-	PrivatelinkDeleteTimeout                int64
-	PrivatelinkAllowedAccountsAddTimeout    int64
-	PrivatelinkAllowedAccountsRemoveTimeout int64
-	DataConnectorCreateTimeout              int64
-	DataConnectorSettingsUpdateTimeout      int64
-	DataConnectorDeleteTimeout              int64
-	DataConnectorStatusUpdateTimeout        int64
-	PostgresCredentialCreateTimeout         int64
-	PostgresCredentialDeleteTimeout         int64
-	PrivateSpaceCreateTimeout               int64
+	MTLSProvisionTimeout                     int64
+	MTLSDeprovisionTimeout                   int64
+	MTLSIPRuleCreateTimeout                  int64
+	MTLSCertificateCreateTimeout             int64
+	MTLSCertificateDeleteTimeout             int64
+	KafkaCGCreateTimeout                     int64
+	KafkaCGDeleteTimeout                     int64
+	KafkaTopicCreateTimeout                  int64
+	KafkaTopicUpdateTimeout                  int64
+	PrivatelinkCreateTimeout                 int64
+	PrivatelinkDeleteTimeout                 int64
+	PrivatelinkAllowedAccountsAddTimeout     int64
+	PrivatelinkAllowedAccountsRemoveTimeout  int64
+	DataConnectorCreateTimeout               int64
+	DataConnectorSettingsUpdateTimeout       int64
+	DataConnectorDeleteTimeout               int64
+	DataConnectorStatusUpdateTimeout         int64
+	PostgresCredentialCreateTimeout          int64
+	PostgresCredentialPreCreateVerifyTimeout int64
+	PostgresCredentialDeleteTimeout          int64
+	PrivateSpaceCreateTimeout                int64
 
 	// Custom Delays
 	PostgresSettingsModifyDelay int64
@@ -91,26 +93,27 @@ type Config struct {
 
 func NewConfig() *Config {
 	c := &Config{
-		MTLSProvisionTimeout:                    DefaultMTLSProvisionTimeout,
-		MTLSDeprovisionTimeout:                  DefaultMTLSMTLSDeprovisionTimeout,
-		MTLSIPRuleCreateTimeout:                 DefaultMTLSIPRuleCreateTimeout,
-		MTLSCertificateCreateTimeout:            DefaultMTLSCertificateCreateTimeout,
-		MTLSCertificateDeleteTimeout:            DefaultMTLSCertificateDeleteTimeout,
-		KafkaCGCreateTimeout:                    DefaultKafkaCGCreateTimeout,
-		KafkaCGDeleteTimeout:                    DefaultKafkaCGDeleteTimeout,
-		KafkaTopicCreateTimeout:                 DefaultKafkaTopicCreateTimeout,
-		KafkaTopicUpdateTimeout:                 DefaultKafkaTopicUpdateTimeout,
-		PrivatelinkCreateTimeout:                DefaultPrivatelinkCreateTimeoutt,
-		PrivatelinkDeleteTimeout:                DefaultPrivatelinkDeleteTimeout,
-		PrivatelinkAllowedAccountsAddTimeout:    DefaultPrivatelinkAllowedAccountsAddTimeout,
-		PrivatelinkAllowedAccountsRemoveTimeout: DefaultPrivatelinkAllowedAccountsRemoveTimeout,
-		DataConnectorCreateTimeout:              DefaultDataConnectorCreateTimeout,
-		DataConnectorSettingsUpdateTimeout:      DefaultDataConnectorSettingsUpdateTimeout,
-		DataConnectorDeleteTimeout:              DefaultDataConnectorDeleteTimeout,
-		DataConnectorStatusUpdateTimeout:        DefaultDataConnectorStatusUpdateTimeout,
-		PostgresCredentialCreateTimeout:         DefaultPostgresCredentialCreateTimeout,
-		PostgresCredentialDeleteTimeout:         DefaultPostgresCredentialDeleteTimeout,
-		PrivateSpaceCreateTimeout:               DefaultPrivateSpaceCreateTimeout,
+		MTLSProvisionTimeout:                     DefaultMTLSProvisionTimeout,
+		MTLSDeprovisionTimeout:                   DefaultMTLSMTLSDeprovisionTimeout,
+		MTLSIPRuleCreateTimeout:                  DefaultMTLSIPRuleCreateTimeout,
+		MTLSCertificateCreateTimeout:             DefaultMTLSCertificateCreateTimeout,
+		MTLSCertificateDeleteTimeout:             DefaultMTLSCertificateDeleteTimeout,
+		KafkaCGCreateTimeout:                     DefaultKafkaCGCreateTimeout,
+		KafkaCGDeleteTimeout:                     DefaultKafkaCGDeleteTimeout,
+		KafkaTopicCreateTimeout:                  DefaultKafkaTopicCreateTimeout,
+		KafkaTopicUpdateTimeout:                  DefaultKafkaTopicUpdateTimeout,
+		PrivatelinkCreateTimeout:                 DefaultPrivatelinkCreateTimeout,
+		PrivatelinkDeleteTimeout:                 DefaultPrivatelinkDeleteTimeout,
+		PrivatelinkAllowedAccountsAddTimeout:     DefaultPrivatelinkAllowedAccountsAddTimeout,
+		PrivatelinkAllowedAccountsRemoveTimeout:  DefaultPrivatelinkAllowedAccountsRemoveTimeout,
+		DataConnectorCreateTimeout:               DefaultDataConnectorCreateTimeout,
+		DataConnectorSettingsUpdateTimeout:       DefaultDataConnectorSettingsUpdateTimeout,
+		DataConnectorDeleteTimeout:               DefaultDataConnectorDeleteTimeout,
+		DataConnectorStatusUpdateTimeout:         DefaultDataConnectorStatusUpdateTimeout,
+		PostgresCredentialPreCreateVerifyTimeout: DefaultPostgresCredentialPreCreateVerifyTimeout,
+		PostgresCredentialCreateTimeout:          DefaultPostgresCredentialCreateTimeout,
+		PostgresCredentialDeleteTimeout:          DefaultPostgresCredentialDeleteTimeout,
+		PrivateSpaceCreateTimeout:                DefaultPrivateSpaceCreateTimeout,
 
 		PostgresSettingsModifyDelay: DefaultPostgresSettingsModifyDelay,
 		ConnectMappingModifyDelay:   DefaultConnectMappingModifyDelay,
@@ -293,6 +296,10 @@ func (c *Config) applySchema(d *schema.ResourceData) (err error) {
 
 			if v, ok := timeoutsConfig["data_connector_status_update_timeout"].(int); ok {
 				c.DataConnectorStatusUpdateTimeout = int64(v)
+			}
+
+			if v, ok := timeoutsConfig["postgres_credential_pre_create_verify_timeout"].(int); ok {
+				c.PostgresCredentialPreCreateVerifyTimeout = int64(v)
 			}
 
 			if v, ok := timeoutsConfig["postgres_credential_create_timeout"].(int); ok {

--- a/herokux/config.go
+++ b/herokux/config.go
@@ -34,7 +34,7 @@ const (
 	DefaultDataConnectorSettingsUpdateTimeout       = int64(10)
 	DefaultDataConnectorDeleteTimeout               = int64(10)
 	DefaultDataConnectorStatusUpdateTimeout         = int64(10)
-	DefaultPostgresCredentialPreCreateVerifyTimeout = int64(30)
+	DefaultPostgresCredentialPreCreateVerifyTimeout = int64(60)
 	DefaultPostgresCredentialCreateTimeout          = int64(10)
 	DefaultPostgresCredentialDeleteTimeout          = int64(10)
 	DefaultPrivateSpaceCreateTimeout                = int64(20)

--- a/herokux/config.go
+++ b/herokux/config.go
@@ -34,7 +34,7 @@ const (
 	DefaultDataConnectorSettingsUpdateTimeout       = int64(10)
 	DefaultDataConnectorDeleteTimeout               = int64(10)
 	DefaultDataConnectorStatusUpdateTimeout         = int64(10)
-	DefaultPostgresCredentialPreCreateVerifyTimeout = int64(60)
+	DefaultPostgresCredentialPreCreateVerifyTimeout = int64(30)
 	DefaultPostgresCredentialCreateTimeout          = int64(10)
 	DefaultPostgresCredentialDeleteTimeout          = int64(10)
 	DefaultPrivateSpaceCreateTimeout                = int64(20)

--- a/herokux/provider.go
+++ b/herokux/provider.go
@@ -214,8 +214,8 @@ func New() *schema.Provider {
 						"postgres_credential_pre_create_verify_timeout": {
 							Type:         schema.TypeInt,
 							Optional:     true,
-							Default:      30,
-							ValidateFunc: validation.IntAtLeast(20),
+							Default:      60,
+							ValidateFunc: validation.IntAtLeast(30),
 						},
 
 						"postgres_credential_create_timeout": {

--- a/herokux/provider.go
+++ b/herokux/provider.go
@@ -211,6 +211,13 @@ func New() *schema.Provider {
 							ValidateFunc: validation.IntAtLeast(5),
 						},
 
+						"postgres_credential_pre_create_verify_timeout": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Default:      30,
+							ValidateFunc: validation.IntAtLeast(20),
+						},
+
 						"postgres_credential_create_timeout": {
 							Type:         schema.TypeInt,
 							Optional:     true,

--- a/herokux/provider.go
+++ b/herokux/provider.go
@@ -214,8 +214,8 @@ func New() *schema.Provider {
 						"postgres_credential_pre_create_verify_timeout": {
 							Type:         schema.TypeInt,
 							Optional:     true,
-							Default:      60,
-							ValidateFunc: validation.IntAtLeast(30),
+							Default:      30,
+							ValidateFunc: validation.IntAtLeast(20),
 						},
 
 						"postgres_credential_create_timeout": {

--- a/herokux/provider.go
+++ b/herokux/provider.go
@@ -214,7 +214,7 @@ func New() *schema.Provider {
 						"postgres_credential_pre_create_verify_timeout": {
 							Type:         schema.TypeInt,
 							Optional:     true,
-							Default:      30,
+							Default:      45,
 							ValidateFunc: validation.IntAtLeast(20),
 						},
 

--- a/herokux/resource_herokux_postgres_credential.go
+++ b/herokux/resource_herokux_postgres_credential.go
@@ -195,7 +195,7 @@ func resourceHerokuxPostgresCredentialCreate(ctx context.Context, d *schema.Reso
 
 	shouldVerifyDBCredAvail := ContainsString([]string{"premium", "private", "shield"}, dbPlan)
 
-	log.Printf("[DEBUG] Should verify postgre's %s Fork/Follow status prior to creating credential: %v", postgresID, shouldVerifyDBCredAvail)
+	log.Printf("[DEBUG] Should verify postgres's %s Fork/Follow status prior to creating credential: %v", postgresID, shouldVerifyDBCredAvail)
 
 	if shouldVerifyDBCredAvail {
 		forkFollowStatusChecker := func() (interface{}, string, error) {
@@ -211,11 +211,11 @@ func resourceHerokuxPostgresCredentialCreate(ctx context.Context, d *schema.Reso
 
 			var forkFollowStatus string
 			for _, i := range forkFollowInfo.Values {
-				forkFollowStatus = strings.ToLower(strings.Split(i.(string), " ")[0])
+				forkFollowStatus = i.(string)
 			}
 
-			if forkFollowStatus != "Available" {
-				log.Printf("[DEBUG] postgres %s HA status is still %s", postgresID, forkFollowStatus)
+			if forkFollowStatus == "Temporarily Unavailable" {
+				log.Printf("[DEBUG] postgres %s Fork/Follow status is still %s", postgresID, forkFollowStatus)
 				return db, forkFollowStatus, nil
 			}
 

--- a/herokux/resource_herokux_postgres_credential.go
+++ b/herokux/resource_herokux_postgres_credential.go
@@ -29,6 +29,11 @@ func resourceHerokuxPostgresCredential() *schema.Resource {
 			StateContext: resourceHerokuxPostgresCredentialImport,
 		},
 
+		// https://www.terraform.io/docs/extend/resources/retries-and-customizable-timeouts.html
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(60 * time.Minute),
+		},
+
 		Schema: map[string]*schema.Schema{
 			"postgres_id": {
 				Type:         schema.TypeString,
@@ -202,7 +207,7 @@ func resourceHerokuxPostgresCredentialCreate(ctx context.Context, d *schema.Reso
 			}
 
 			if forkFollowStatus == postgres.DatabaseInfoStatuses.TEMP_UNAVAILABLE.ToString() {
-				log.Printf("[DEBUG] postgres %s Fork/Follow status is still %s", postgresID, forkFollowStatus)
+				log.Printf("[DEBUG] Postgres %s Fork/Follow status is still '%s'", postgresID, forkFollowStatus)
 				return db, forkFollowStatus, nil
 			}
 

--- a/herokux/resource_herokux_postgres_credential.go
+++ b/herokux/resource_herokux_postgres_credential.go
@@ -133,6 +133,7 @@ func resourceHerokuxPostgresCredentialImport(ctx context.Context, d *schema.Reso
 }
 
 func resourceHerokuxPostgresCredentialCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	config := meta.(*Config)
 	client := config.API
 
@@ -147,14 +148,111 @@ func resourceHerokuxPostgresCredentialCreate(ctx context.Context, d *schema.Reso
 		log.Printf("[DEBUG] credential postgres_id is : %v", postgresID)
 	}
 
-	log.Printf("[DEBUG] Creating postgres credential %s", name)
+	// Check the state of the postgres DB to make sure it is in a state to accept credential creation requests.
+	// However, only check for postgres plans types that are either premium#, private0, or shield#.
+	/**
+	when pg is provisioning:
+	{
+	    "message": "preparing",
+	    "waiting?": true
+	}
+	*/
+
+	log.Printf("[DEBUG] Checking if postgres %s is available for credential creation", name)
+	db, _, getErr := client.Postgres.GetDB(postgresID)
+	if getErr != nil {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  fmt.Sprintf("unable to fetch info for postgres %s to determine if it is available for credential creation", postgresID),
+			Detail:   getErr.Error(),
+		})
+		return diags
+	}
+
+	dbPlanInfo, dbPlanInfoErr := db.RetrieveSpecificInfo(postgres.DatabaseInfoNames.PLAN.ToString())
+	if dbPlanInfoErr != nil {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  fmt.Sprintf("unable to get plan info postgres %s to determine if it is available for credential creation", postgresID),
+			Detail:   dbPlanInfoErr.Error(),
+		})
+		return diags
+	}
+
+	// Essentially we are looking to extract the zero-index value from this JSON response:
+	//         {
+	//            "name": "Plan",
+	//            "values": [
+	//                "Premium 0"
+	//            ]
+	//        }
+	var dbPlan string
+	for _, i := range dbPlanInfo.Values {
+		dbPlan = strings.ToLower(strings.Split(i.(string), " ")[0]) // returns "premium"
+	}
+
+	log.Printf("[DEBUG] Postgres %s's plan is %s", postgresID, dbPlan)
+
+	shouldVerifyDBCredAvail := ContainsString([]string{"premium", "private", "shield"}, dbPlan)
+
+	log.Printf("[DEBUG] Should verify postgre's %s Fork/Follow status prior to creating credential: %v", postgresID, shouldVerifyDBCredAvail)
+
+	if shouldVerifyDBCredAvail {
+		forkFollowStatusChecker := func() (interface{}, string, error) {
+			db, _, getErr := client.Postgres.GetDB(postgresID)
+			if getErr != nil {
+				return nil, "Unknown", getErr
+			}
+
+			forkFollowInfo, forkFollowInfoErr := db.RetrieveSpecificInfo(postgres.DatabaseInfoNames.HASTATUS.ToString())
+			if forkFollowInfoErr != nil {
+				return nil, "Unknown", fmt.Errorf("unable to get HA Status info postgres %s to determine if it is available for credential creation", postgresID)
+			}
+
+			var forkFollowStatus string
+			for _, i := range forkFollowInfo.Values {
+				forkFollowStatus = strings.ToLower(strings.Split(i.(string), " ")[0])
+			}
+
+			if forkFollowStatus != "Available" {
+				log.Printf("[DEBUG] postgres %s HA status is still %s", postgresID, forkFollowStatus)
+				return db, forkFollowStatus, nil
+			}
+
+			return db, forkFollowStatus, nil
+		}
+
+		stateConf := &resource.StateChangeConf{
+			Pending:      []string{"Temporarily Unavailable"},
+			Target:       []string{"Available"},
+			Refresh:      forkFollowStatusChecker,
+			Timeout:      time.Duration(config.PostgresCredentialPreCreateVerifyTimeout) * time.Minute,
+			PollInterval: StateRefreshPollInterval,
+		}
+
+		if _, err := stateConf.WaitForStateContext(ctx); err != nil {
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.Error,
+				Summary:  fmt.Sprintf("unable to create credential on postgres %s", postgresID),
+				Detail:   fmt.Sprintf("postgres %s's Fork/Follow status must be set to 'Available' before creating a credential", postgresID),
+			})
+			return diags
+		}
+	}
+
+	log.Printf("[DEBUG] Creating postgres credential %s on postgres %s", name, postgresID)
 
 	_, _, createErr := client.Postgres.CreateCredential(postgresID, name)
 	if createErr != nil {
-		return diag.FromErr(createErr)
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  fmt.Sprintf("unable to create credential on postgres %s", postgresID),
+			Detail:   createErr.Error(),
+		})
+		return diags
 	}
 
-	log.Printf("[DEBUG] Waiting for postgres credential %s to be active", name)
+	log.Printf("[DEBUG] Waiting for postgres credential %s on postgres %s to be active", name, postgresID)
 
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{postgres.CredentialStates.WAITFORPROVISIONING.ToString(),
@@ -168,6 +266,8 @@ func resourceHerokuxPostgresCredentialCreate(ctx context.Context, d *schema.Reso
 	if _, err := stateConf.WaitForStateContext(ctx); err != nil {
 		return diag.Errorf("error waiting for postgres credential %s to be active on %s: %s", name, postgresID, err.Error())
 	}
+
+	log.Printf("[DEBUG] Created postgres credential %s on postgres %s", name, postgresID)
 
 	// Set the ID to be a composite of the postgres ID and the credential name.
 	d.SetId(fmt.Sprintf("%s:%s", postgresID, name))

--- a/herokux/resource_herokux_postgres_credential_test.go
+++ b/herokux/resource_herokux_postgres_credential_test.go
@@ -40,6 +40,47 @@ func TestAccHerokuxPostgresCredential_Basic(t *testing.T) {
 	})
 }
 
+func TestAccHerokuxPostgresCredential_WithPremiumPG(t *testing.T) {
+	orgName := testAccConfig.GetAnyOrganizationOrSkip(t)
+	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
+	plan := "premium-0"
+	credName := fmt.Sprintf("pgcredtest-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"heroku": {
+				VersionConstraint: "4.4.1",
+				Source:            "heroku/heroku",
+			},
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckHerokuxPostgresCredential_basicWithHerokuResource(appName, orgName, plan, credName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(
+						"herokux_postgres_credential.foobar", "postgres_id"),
+					resource.TestCheckResourceAttr(
+						"herokux_postgres_credential.foobar", "name", credName),
+					resource.TestCheckResourceAttr(
+						"herokux_postgres_credential.foobar", "state", "active"),
+					resource.TestCheckResourceAttrSet(
+						"herokux_postgres_credential.foobar", "database"),
+					resource.TestCheckResourceAttrSet(
+						"herokux_postgres_credential.foobar", "host"),
+					resource.TestCheckResourceAttrSet(
+						"herokux_postgres_credential.foobar", "port"),
+					resource.TestCheckResourceAttrSet(
+						"herokux_postgres_credential.foobar", "uuid"),
+					resource.TestCheckResourceAttr(
+						"herokux_postgres_credential.foobar", "secrets.#", "1"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckHerokuxPostgresCredential_basic(postgresID, name string) string {
 	return fmt.Sprintf(`
 resource "herokux_postgres_credential" "foobar" {
@@ -47,4 +88,39 @@ resource "herokux_postgres_credential" "foobar" {
 	name = "%s"
 }
 `, postgresID, name)
+}
+
+func testAccCheckHerokuxPostgresCredential_basicWithHerokuResource(appName, orgName, addonPlan, name string) string {
+	return fmt.Sprintf(`
+terraform {
+  required_providers {
+    heroku = {
+      source = "heroku/heroku"
+      version = ">= 4.0"
+    }
+  }
+}
+
+provider "heroku" {
+}
+
+resource "heroku_app" "foobar" {
+  name   = "%s"
+  region = "us"
+
+  organization {
+    name = "%s"
+  }
+}
+
+resource "heroku_addon" "database" {
+  app  = heroku_app.foobar.name
+  plan = "heroku-postgresql:%s"
+}
+
+resource "herokux_postgres_credential" "foobar" {
+  postgres_id = heroku_addon.database.id
+  name = "%s"
+}
+`, appName, orgName, addonPlan, name)
 }


### PR DESCRIPTION
It appears `herokux_postgres_credential` will fail if the HA standby is not ready/under maintenance:

```
Error: POST https://postgres-api.heroku.com/postgres/v0/databases/<UUID>/credentials: 422 {"id":"unprocessable_entity","message":"Your standby is currently undergoing maintenance, making some operations unavailable at this time. Please try again later."}
```

On initial investigation, one can create the credential after `Fork/Follow` is Available, but before `HA Status` becomes Available.

Initial solution is the wait until both statuses are 'Availabile'.

Starting at `Standard0`, forks/followers becomes available and `Premium0` is when HA becomes available.