### PR TITLE
More robust handling of pg cred precreate verify

### DIFF
--- a/api/postgres/database.go
+++ b/api/postgres/database.go
@@ -29,9 +29,11 @@ type DatabaseLeader struct {
 
 // DatabaseInfo represents a database's information.
 type DatabaseInfo struct {
-	Name          *string       `json:"name,omitempty"`
-	Values        []interface{} `json:"values,omitempty"` // most of the values are strings
-	ResolveDBName *bool         `json:"resolve_db_name,omitempty"`
+	Name          *string `json:"name,omitempty"`
+	ResolveDBName *bool   `json:"resolve_db_name,omitempty"`
+
+	// Most of the values are strings and only have one element.
+	Values []interface{} `json:"values,omitempty"`
 }
 
 func (d *Database) RetrieveSpecificInfo(name string) (*DatabaseInfo, error) {

--- a/docs/resources/postgres_credential.md
+++ b/docs/resources/postgres_credential.md
@@ -21,9 +21,10 @@ Furthermore, this resource renders the `secrets.username` & `secrets.password` a
 Please ensure that your state file is properly secured and encrypted at rest.
 
 ### Resource Timeouts
-During creation and deletion, this resource checks the status of the credential. Additionally, for Premium, Private,
-and Shield databases, the provider verifies the database's Fork/Follow status prior to creating the credential.
-Credentials cannot be created on these databases if the Fork/Follow status is not set to 'Available'.
+During creation and deletion, this resource checks the status of the credential creation or deletion.
+Additionally, for Premium, Private, and Shield databases, the provider verifies the Postgres database's Fork/Follow
+and HA (high availability) statuses prior to creating the credential. Credentials cannot be created on the database
+if both statuses are not set to 'Available'.
 
 All the aforementioned timeouts can be customized via the `timeouts.postgres_credential_create_verify_timeout` and
 `timeouts.postgres_credential_delete_verify_timeout` attributes in your `provider` block.
@@ -35,7 +36,7 @@ provider "herokux" {
   timeouts {
     postgres_credential_create_verify_timeout = 20
     postgres_credential_delete_verify_timeout = 20
-    postgres_credential_pre_create_verify_timeout = 30
+    postgres_credential_pre_create_verify_timeout = 35
   }
 }
 ```


### PR DESCRIPTION
Even after adding a precreate verification check for `herokux_postgres_credential` (#129), it appears that was not enough:

```shell
2021/05/19 12:05:42 [DEBUG] Creating postgres credential pgcredtest-th6xnb73by on postgres 0fba372c-8cfa-4a14-813f-7551132c138d
2021/05/19 12:05:43 [WARN] Got error running Terraform: exit status 1

Error: unable to create credential on postgres 0fba372c-8cfa-4a14-813f-7551132c138d

  with herokux_postgres_credential.foobar,
  on terraform_plugin_test.tf line 28, in resource "herokux_postgres_credential" "foobar":
  28: resource "herokux_postgres_credential" "foobar" {

POST
https://postgres-api.heroku.com/postgres/v0/databases/0fba372c-8cfa-4a14-813f-7551132c138d/credentials:
422 {"id":"unprocessable_entity","message":"Your standby is currently
undergoing maintenance, making some operations unavailable at this time.
Please try again later."}
    resource_herokux_postgres_credential_test.go:49: Step 1/1 error: Error running apply: exit status 1

        Error: unable to create credential on postgres 0fba372c-8cfa-4a14-813f-7551132c138d

          with herokux_postgres_credential.foobar,
          on terraform_plugin_test.tf line 28, in resource "herokux_postgres_credential" "foobar":
          28: resource "herokux_postgres_credential" "foobar" {

        POST
        https://postgres-api.heroku.com/postgres/v0/databases/0fba372c-8cfa-4a14-813f-7551132c138d/credentials:
        422 {"id":"unprocessable_entity","message":"Your standby is currently
        undergoing maintenance, making some operations unavailable at this time.
        Please try again later."}
2021/05/19 12:05:44 [DEBUG] New state was assigned lineage "f25636f9-c967-a933-6f20-296216aae794"
```

Maybe the provider needs to verify more statuses on the PG instance.