### PR TITLE
Update the 'herokux_formation_alert' example to match the documentation

### DIFF
--- a/docs/resources/formation_alert.md
+++ b/docs/resources/formation_alert.md
@@ -93,7 +93,7 @@ resource "herokux_formation_alert" "foobar" {
   threshold = "1202"
   sensitivity = 10
   is_active = true
-  email_reminder_frequency = 1440
+  notification_frequency = 1440
   notification_channels = ["app"]
 
   # Tells Terraform that this formation alert resource must be created/updated

--- a/herokux/resource_herokux_formation_alert.go
+++ b/herokux/resource_herokux_formation_alert.go
@@ -142,7 +142,7 @@ func constructAppAlertOpts(d *schema.ResourceData, alertName string) *metrics.Fo
 
 	if v, ok := d.GetOk("notification_frequency"); ok {
 		opts.ReminderFrequency = v.(int)
-		log.Printf("[DEBUG] %s alert email_reminder_frequency: %v", alertName, opts.ReminderFrequency)
+		log.Printf("[DEBUG] %s alert notification_frequency: %v", alertName, opts.ReminderFrequency)
 	}
 
 	notificationChannels := make([]string, 0)


### PR DESCRIPTION
## Description

The `herokux_formation_alert` documentation describes the correct `notification_frequency` argument, but the example uses `email_reminder_frequency`.

```
│ Error: Unsupported argument
│
│   on modules/heroku.tf line 366, in resource "herokux_formation_alert" "processor":
│  366:   email_reminder_frequency = 1440
│
│ An argument named "email_reminder_frequency" is not expected here.
```

## Tests

N/A