### PR TITLE
Rename herokux_addons to herokux_app_addons

### DIFF
--- a/docs/data-sources/app_addons.md
+++ b/docs/data-sources/app_addons.md
@@ -1,19 +1,19 @@
 ---
 layout: "herokux"
-page_title: "Herokux: herokux_addons"
-sidebar_current: "docs-herokux-datasource-addons-x"
+page_title: "Herokux: herokux_app_addons"
+sidebar_current: "docs-herokux-datasource-app-addons-x"
 description: |-
   Get information about all add-ons installed on a specific App.
 ---
 
-# Data Source: herokux_addons
+# Data Source: herokux_app_addons
 
 Use this data source to get information about all add-ons installed on a specific app.
 
 ## Example Usage
 
 ```hcl-terraform
-data "herokux_addons" "foobar" {
+data "herokux_app_addons" "foobar" {
   app_id = "44e263f7-2e06-403b-9f37-44f0f9bcd5e9"
   addon_service_name = "heroku-postgresql"
 }

--- a/docs/resources/scheduler_job.md
+++ b/docs/resources/scheduler_job.md
@@ -59,8 +59,8 @@ Choose one of the following (case-sensitive):
 * `every_ten_minutes`
 * `every_hour_at_##` - Valid values for `##` are `0`, `10`, `20`, `30`, `40`, `50`.
 * `every_day_at_HH:MM` - Valid values for `HH` and `MM` are (using 24hour time format):
-  * `HH` - `0` through `23`. For example, `5`, `16`, etc. No leading `0` for hours 0-9.
-  * `MM` - either `30` or `00`.
+    * `HH` - `0` through `23`. For example, `5`, `16`, etc. No leading `0` for hours 0-9.
+    * `MM` - either `30` or `00`.
 
 
 ## Attributes Reference

--- a/herokux/data_source_herokux_app_addons.go
+++ b/herokux/data_source_herokux_app_addons.go
@@ -7,9 +7,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func dataSourceHerokuxAddons() *schema.Resource {
+func dataSourceHerokuxAppAddons() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: dataSourceHerokuxAddonsRead,
+		ReadContext: dataSourceHerokuxAppAddonsRead,
 		Schema: map[string]*schema.Schema{
 			"app_id": {
 				Type:     schema.TypeString,
@@ -32,7 +32,7 @@ func dataSourceHerokuxAddons() *schema.Resource {
 	}
 }
 
-func dataSourceHerokuxAddonsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceHerokuxAppAddonsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	platformAPI := meta.(*Config).PlatformAPI
 
 	appID := getAppID(d)

--- a/herokux/data_source_herokux_app_addons_test.go
+++ b/herokux/data_source_herokux_app_addons_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-func TestAccDatasourceHerokuxAddons_Basic(t *testing.T) {
+func TestAccDatasourceHerokuxAppAddons_Basic(t *testing.T) {
 	appID := testAccConfig.GetAppIDorSkip(t)
 	addonServiceName := ""
 
@@ -21,18 +21,18 @@ func TestAccDatasourceHerokuxAddons_Basic(t *testing.T) {
 				Config: testAccCheckHerokuxAddons_Basic(appID, addonServiceName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
-						"data.herokux_addons.foobar", "app_id", appID),
+						"data.herokux_app_addons.foobar", "app_id", appID),
 					resource.TestCheckResourceAttr(
-						"data.herokux_addons.foobar", "addon_service_name", addonServiceName),
+						"data.herokux_app_addons.foobar", "addon_service_name", addonServiceName),
 					resource.TestCheckResourceAttrSet(
-						"data.herokux_addons.foobar", "addons"),
+						"data.herokux_app_addons.foobar", "addons"),
 				),
 			},
 		},
 	})
 }
 
-func TestAccDatasourceHerokuxAddons_Filter(t *testing.T) {
+func TestAccDatasourceHerokuxAppAddons_Filter(t *testing.T) {
 	appID := testAccConfig.GetAppIDorSkip(t)
 	addonServiceName := "heroku-postgresql"
 
@@ -46,18 +46,18 @@ func TestAccDatasourceHerokuxAddons_Filter(t *testing.T) {
 				Config: testAccCheckHerokuxAddons_Basic(appID, addonServiceName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
-						"data.herokux_addons.foobar", "app_id", appID),
+						"data.herokux_app_addons.foobar", "app_id", appID),
 					resource.TestCheckResourceAttr(
-						"data.herokux_addons.foobar", "addon_service_name", addonServiceName),
+						"data.herokux_app_addons.foobar", "addon_service_name", addonServiceName),
 					resource.TestCheckResourceAttrSet(
-						"data.herokux_addons.foobar", "addons"),
+						"data.herokux_app_addons.foobar", "addons"),
 				),
 			},
 		},
 	})
 }
 
-func TestAccDatasourceHerokuxAddons_NotFound(t *testing.T) {
+func TestAccDatasourceHerokuxAppAddons_NotFound(t *testing.T) {
 	appID := testAccConfig.GetAppIDorSkip(t)
 	addonServiceName := "non-existent"
 
@@ -77,7 +77,7 @@ func TestAccDatasourceHerokuxAddons_NotFound(t *testing.T) {
 
 func testAccCheckHerokuxAddons_Basic(appID, addonServiceName string) string {
 	return fmt.Sprintf(`
-data "herokux_addons" "foobar" {
+data "herokux_app_addons" "foobar" {
   app_id = "%s"
   addon_service_name = "%s"
 }

--- a/herokux/provider.go
+++ b/herokux/provider.go
@@ -281,7 +281,7 @@ func New() *schema.Provider {
 
 		DataSourcesMap: map[string]*schema.Resource{
 			//"herokux_connect": dataSourceHerokuxConnect(),
-			"herokux_addons":                    dataSourceHerokuxAddons(),
+			"herokux_app_addons":                dataSourceHerokuxAppAddons(),
 			"herokux_kafka_mtls_iprules":        dataSourceHerokuxMTLSIPRules(),
 			"herokux_postgres_mtls_certificate": dataSourceHerokuxPostgresMTLSCertificate(),
 			"herokux_registry_image":            dataSourceHerokuxRegistryImage(),


### PR DESCRIPTION
Renaming the existing data source because:
1) The original intent of this data source is scoped by app.
2) Introduce a new `herokux_addons` data source that is more generic.