### PR TITLE
[BUGFIX] Invalid JSON:API payload for Scheduler Jobs

### DIFF
--- a/api/scheduler/job.go
+++ b/api/scheduler/job.go
@@ -103,12 +103,17 @@ func (s *Scheduler) Create(appID string, opts *JobRequest) (*JobModifyResponse, 
 
 	body := struct {
 		Data struct {
+			Type       string      `json:"type"`
 			Attributes *JobRequest `json:"attributes"`
 		} `json:"data"`
 	}{
 		Data: struct {
+			Type       string      `json:"type"`
 			Attributes *JobRequest `json:"attributes"`
-		}(struct{ Attributes *JobRequest }{Attributes: opts}),
+		}(struct {
+			Type       string
+			Attributes *JobRequest
+		}{Type: "jobs", Attributes: opts}),
 	}
 
 	// Execute the request
@@ -124,12 +129,17 @@ func (s *Scheduler) Update(appID, jobID string, opts *JobRequest) (*JobModifyRes
 
 	body := struct {
 		Data struct {
+			Type       string      `json:"type"`
 			Attributes *JobRequest `json:"attributes"`
 		} `json:"data"`
 	}{
 		Data: struct {
+			Type       string      `json:"type"`
 			Attributes *JobRequest `json:"attributes"`
-		}(struct{ Attributes *JobRequest }{Attributes: opts}),
+		}(struct {
+			Type       string
+			Attributes *JobRequest
+		}{Type: "jobs", Attributes: opts}),
 	}
 
 	// Execute the request


### PR DESCRIPTION
## Description
The  request bodies for scheduler job `Create` and `Update` are [not valid JSON:API without a `type` member.](https://jsonapi.org/format/#crud)
 
 
## Error output
From [this failed atlantis apply](https://github.com/devforce/trailhead-terraform/pull/1370#issuecomment-1090355347) job:

```

Error: Unable to create schedule job for app <...>

  with module.<...>.herokux_scheduler_job.job["something"],
  on ../../../modules/<...>.tf line 123, in resource "herokux_scheduler_job" "job":
 123: resource "herokux_scheduler_job" "job" {

POST
https://particleboard.heroku.com/apps/<...>/jobs:
400 {"errors":[{"detail":"Check out http://jsonapi.org/format/#crud for more
info.","source":{"pointer":"/data/type"},"status":"400","title":"Missing type
in data parameter"}]}

Error: Unable to create schedule job for app  <...>

  with module.<...>.herokux_scheduler_job.job["something else"],
  on ../../../modules/<...>.tf line 123, in resource "herokux_scheduler_job" "job":
 123: resource "herokux_scheduler_job" "job" {

POST
https://particleboard.heroku.com/apps/<...>/jobs:
400 {"errors":[{"detail":"Check out http://jsonapi.org/format/#crud for more
info.","source":{"pointer":"/data/type"},"status":"400","title":"Missing type
in data parameter"}]}
module.<...>.herokux_scheduler_job.job["something"]: Creating...
module.<...>..herokux_scheduler_job.job["something else"]: Creating...


```

## Tests
If you have made any modifications to a resource or the API client, please run the appropriate tests
and paste the scrubbed test output below:

```shell
...
```

^^^ Sorry, I only ran  the provider tests via `make test` (not the Acceptance tests)
