### PR TITLE
Fix sample codes about of argument `app_id`

### DIFF
--- a/docs/resources/app_github_integration.md
+++ b/docs/resources/app_github_integration.md
@@ -38,7 +38,7 @@ resource "heroku_pipeline" "foobar" {
 
 # Couple app to pipeline.
 resource "heroku_pipeline_coupling" "staging" {
-  app      = heroku_app.staging.id
+  app_id   = heroku_app.staging.id
   pipeline = heroku_pipeline.foobar.id
   stage    = "staging"
 }

--- a/docs/resources/formation_alert.md
+++ b/docs/resources/formation_alert.md
@@ -63,7 +63,7 @@ resource "heroku_app" "foobar" {
 }
 
 resource "heroku_slug" "foobar" {
-  app      = heroku_app.foobar.id
+  app_id   = heroku_app.foobar.id
   file_url = "url_to_slug_artifact"
 
   process_types = {
@@ -72,12 +72,12 @@ resource "heroku_slug" "foobar" {
 }
 
 resource "heroku_app_release" "foobar" {
-  app = heroku_app.foobar.id
+  app_id  = heroku_app.foobar.id
   slug_id = heroku_slug.foobar.id
 }
 
 resource "heroku_formation" "foobar" {
-  app = heroku_app.foobar.id
+  app_id = heroku_app.foobar.id
   type = var.process_type
   quantity = 8
   size = var.dyno_size

--- a/docs/resources/formation_autoscaling.md
+++ b/docs/resources/formation_autoscaling.md
@@ -74,7 +74,7 @@ resource "heroku_app" "foobar" {
 }
 
 resource "heroku_slug" "foobar" {
-  app      = heroku_app.foobar.id
+  app_id   = heroku_app.foobar.id
   file_url = "url_to_slug_artifact"
 
   process_types = {
@@ -83,12 +83,12 @@ resource "heroku_slug" "foobar" {
 }
 
 resource "heroku_app_release" "foobar" {
-  app = heroku_app.foobar.id
+  app_id  = heroku_app.foobar.id
   slug_id = heroku_slug.foobar.id
 }
 
 resource "heroku_formation" "foobar" {
-  app = heroku_app.foobar.id
+  app_id = heroku_app.foobar.id
   type = var.process_type
   quantity = 8
   size = var.dyno_size


### PR DESCRIPTION
## Description

Some sample codes in resource document contains wrong argument `app` (instead of `app_id`). So this PR fixes it.

cf.
- https://registry.terraform.io/providers/heroku/heroku/latest/docs/resources/slug
- https://registry.terraform.io/providers/heroku/heroku/latest/docs/resources/pipeline_coupling
- https://registry.terraform.io/providers/heroku/heroku/latest/docs/resources/app_release
- https://registry.terraform.io/providers/heroku/heroku/latest/docs/resources/formation

## Tests

N/A