### PR TITLE
Support non-UUID Redis IDs

### DIFF
--- a/herokux/resource_herokux_redis_config.go
+++ b/herokux/resource_herokux_redis_config.go
@@ -2,11 +2,12 @@ package herokux
 
 import (
 	"context"
+	"log"
+
 	"github.com/davidji99/terraform-provider-herokux/api/redis"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"log"
 )
 
 var (
@@ -32,10 +33,9 @@ func resourceHerokuxRedisConfig() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"redis_id": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.IsUUID,
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
 			},
 
 			"maxmemory_policy": {

--- a/herokux/resource_herokux_redis_maintenance_window.go
+++ b/herokux/resource_herokux_redis_maintenance_window.go
@@ -3,11 +3,11 @@ package herokux
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"log"
 	"regexp"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func resourceHerokuxRedisMaintenanceWindow() *schema.Resource {
@@ -25,10 +25,9 @@ func resourceHerokuxRedisMaintenanceWindow() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"redis_id": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.IsUUID,
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
 			},
 
 			"window": {


### PR DESCRIPTION
The ID for a Redis addon can now be a name string like `foo-blah-12345`, so let's allow this when setting up these resources. Took a similar approach to #375, and removed the validation.